### PR TITLE
[RN] Note visualization fails in 3.0.1

### DIFF
--- a/src/components/Graph/gl/GraphBasalGl.js
+++ b/src/components/Graph/gl/GraphBasalGl.js
@@ -27,23 +27,25 @@ class GraphBasalGl extends GraphRenderLayerGl {
     const width = endTimeOffset - startTimeOffset;
     const height = this.yAxisBasalPixelsPerValue * value;
 
-    const shape = new THREE.Shape();
-    shape.moveTo(0, 0);
-    shape.lineTo(width * this.pixelRatio, 0);
-    shape.lineTo(width * this.pixelRatio, height * this.pixelRatio);
-    shape.lineTo(0, height * this.pixelRatio);
-    shape.moveTo(0, 0);
-    const geometry = new THREE.ShapeGeometry(shape);
-    const object = new THREE.Mesh(geometry, this.basalRectMaterial);
-    this.addAutoScrollableObjectToScene(this.scene, object, {
-      x: startTimeOffset,
-      y: this.yAxisBottomOfBasal,
-      z: this.zStart,
-      contentOffsetX,
-      pixelsPerSecond,
-      shouldScrollX: true,
-      shouldScaleX: true,
-    });
+    if (width > 0 && height > 0) {
+      const shape = new THREE.Shape();
+      shape.moveTo(0, 0);
+      shape.lineTo(width * this.pixelRatio, 0);
+      shape.lineTo(width * this.pixelRatio, height * this.pixelRatio);
+      shape.lineTo(0, height * this.pixelRatio);
+      shape.moveTo(0, 0);
+      const geometry = new THREE.ShapeGeometry(shape);
+      const object = new THREE.Mesh(geometry, this.basalRectMaterial);
+      this.addAutoScrollableObjectToScene(this.scene, object, {
+        x: startTimeOffset,
+        y: this.yAxisBottomOfBasal,
+        z: this.zStart,
+        contentOffsetX,
+        pixelsPerSecond,
+        shouldScrollX: true,
+        shouldScaleX: true,
+      });
+    }
 
     return {
       x: startTimeOffset,


### PR DESCRIPTION
Ensure we aren't trying to render empty basal rects (latest Expo/three.js doesn't seem happy with zero height geometry). We already had this fix for bolus. This just extends it to basal as well. I don't believe there are any remaining occurrences of this bug now.

This fix was done in release/3.0.1 branch. The PR is to merge to develop. Probably should have done it in develop and then merged to release/3.0.1. Sorry about that. Once this PR is approved, and once release/3.0.1 branch is stable and passes QA, I'll prep a PR for merge to master as well.