### PR TITLE
Fix longstanding issue with sortAndDeduplicate

### DIFF
--- a/src/models/GraphData.js
+++ b/src/models/GraphData.js
@@ -326,7 +326,7 @@ export default class GraphData {
       const dataWithoutDuplicates = [previousItem];
       for (let i = 1; i < processedData.length; i += 1) {
         const { value, time } = data[i];
-        if (value !== previousItem.value && time !== previousItem.time) {
+        if (value !== previousItem.value || time !== previousItem.time) {
           dataWithoutDuplicates.push(data[i]);
         }
         previousItem = data[i];


### PR DESCRIPTION
Fix a longstanding issue with sortAndDeduplicate exposed by recent testing of fix for carbs without associated bolus

When processing graph data on client, after sorting items, an item is not a dup if either its value or time is different from prior item.

This fixes recent issues found in https://trello.com/c/28zioEkU/614-rn-display-carbs-from-platform-which-are-not-associated-with-bolus-wizard-event-in-tidepool-mobile