### PR TITLE
Disable auto-updating of JS bundle for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,7 +209,7 @@ npm-debug.log
 
 # Dynamic Macros
 /ios/Exponent/Supporting/Generated/EXDynamicMacros.h
-android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
+# android/app/src/main/java/host/exp/exponent/generated/AppConstants.java # Don't exclude this, we need it committed with ARE_REMOTE_UPDATES_ENABLED set to false
 android/app/src/main/java/host/exp/exponent/generated/ExponentBuildConstants.java
 android/app/srcandroidTest/java/host/exp/exponent/generated/TestBuildConstants.java
 .kernel-ngrok-url

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,12 @@ matrix:
         - npx eslint src/ --max-warnings 0
         - yarn test --forceExit
         - npx expo login -u tidepool -p $EXPO_PASSWORD
-        - npx expo publish
+        - npx expo publish --release-channel travis
       script:
+        # Update release channel to travis
+        - bash scripts/update-release-channel.sh travis
+
+        # Move to ios dir for iOS build
         - pushd ios
 
         # Add signing certs to keychain
@@ -88,9 +92,15 @@ matrix:
         - npx eslint src/ --max-warnings 0
         - yarn test --forceExit
         - npx expo login -u tidepool -p $EXPO_PASSWORD
-        - npx expo publish
+        - npx expo publish --release-channel travis
       script:
+        # Update release channel to travis
+        - bash scripts/update-release-channel.sh travis
+
+        # Move to android dir for Android build
         - pushd android
+
+        # Build the apk
         - "./gradlew :app:assembleProdMinSdkProdKernelRelease"
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ matrix:
         - npx eslint src/ --max-warnings 0
         - yarn test --forceExit
         - npx expo login -u tidepool -p $EXPO_PASSWORD
-        - npx expo publish --release-channel travis
+        - npx expo publish --release-channel travis-ios
       script:
         # Update release channel to travis
-        - bash scripts/update-release-channel.sh travis
+        - bash scripts/update-release-channel.sh travis-ios
 
         # Move to ios dir for iOS build
         - pushd ios
@@ -92,10 +92,10 @@ matrix:
         - npx eslint src/ --max-warnings 0
         - yarn test --forceExit
         - npx expo login -u tidepool -p $EXPO_PASSWORD
-        - npx expo publish --release-channel travis
+        - npx expo publish --release-channel travis-android
       script:
         # Update release channel to travis
-        - bash scripts/update-release-channel.sh travis
+        - bash scripts/update-release-channel.sh travis-android
 
         # Move to android dir for Android build
         - pushd android

--- a/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
+++ b/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
@@ -17,25 +17,16 @@ public class AppConstants {
   public static final String SHELL_APP_SCHEME = "exp0815d1104db745568824ac69a998de27";
   public static final String RELEASE_CHANNEL = "default";
   public static boolean SHOW_LOADING_VIEW_IN_SHELL_APP = false;
-  public static boolean ARE_REMOTE_UPDATES_ENABLED = true;
+  public static boolean ARE_REMOTE_UPDATES_ENABLED = false;
   public static final List<Constants.EmbeddedResponse> EMBEDDED_RESPONSES;
   public static boolean FCM_ENABLED = false;
 
   static {
     List<Constants.EmbeddedResponse> embeddedResponses = new ArrayList<>();
-
-    
-        
-        
-        
-        
-        
-        
-        
         // ADD EMBEDDED RESPONSES HERE
         // START EMBEDDED RESPONSES
         embeddedResponses.add(new Constants.EmbeddedResponse("https://exp.host/@tidepool/Tidepool", "assets://shell-app-manifest.json", "application/json"));
-        embeddedResponses.add(new Constants.EmbeddedResponse("https://d1wp6m56sqw74a.cloudfront.net/%40tidepool%2FTidepool%2F3.0.1%2F68a4210756221d7c05b770cd8bbf2925-31.0.0-android.js", "assets://shell-app.bundle", "application/javascript"));
+        embeddedResponses.add(new Constants.EmbeddedResponse("https://d1wp6m56sqw74a.cloudfront.net/%40tidepool%2FTidepool%2F3.0.3%2Fdd796d5321832166e7e64d9de6a89ddb-32.0.0-android.js", "assets://shell-app.bundle", "application/javascript"));
         // END EMBEDDED RESPONSES
     EMBEDDED_RESPONSES = embeddedResponses;
   }

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -21,5 +21,3 @@ updateReleaseChannel
 expression="s/\<string\>default\<\/string\>/\<string\>"$releaseChannel"\<\/string\>/"
 target_file="ios/tidepool/Supporting/EXShell.plist"
 updateReleaseChannel
-
-cat ios/tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -13,13 +13,13 @@ target_file="android/app/src/main/assets/shell-app-manifest.json"
 updateReleaseChannel
 target_file="android/app/src/main/assets/kernel-manifest.json"
 updateReleaseChannel
-target_file="ios/Tidepool/Supporting/shell-app-manifest.json"
+target_file="ios/tidepool/Supporting/shell-app-manifest.json"
 updateReleaseChannel
-target_file="ios/Tidepool/Supporting/EXShell.json"
+target_file="ios/tidepool/Supporting/EXShell.json"
 updateReleaseChannel
 
 expression="s/\<string\>default\<\/string\>/\<string\>"$releaseChannel"\<\/string\>/"
-target_file="ios/Tidepool/Supporting/EXShell.plist"
+target_file="ios/tidepool/Supporting/EXShell.plist"
 updateReleaseChannel
 
 cat ios/Tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -22,4 +22,4 @@ expression="s/\<string\>default\<\/string\>/\<string\>"$releaseChannel"\<\/strin
 target_file="ios/tidepool/Supporting/EXShell.plist"
 updateReleaseChannel
 
-cat ios/Tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI
+cat ios/tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -4,9 +4,18 @@ set -o nounset
 
 # Update manifests to use specified release channel rather than default
 pwd # remove this later, just testing Travis CI
-sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/shell-app-manifest.json
-sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/kernel-manifest.json
-sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/shell-app-manifest.json
-sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/EXShell.json
-sed -i .bak "s/\<string\>default\<\/string\>/\<string\>$1\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+
+if [ "$(uname)" == "Darwin" ]; then
+    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" android/app/src/main/assets/shell-app-manifest.json
+    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" android/app/src/main/assets/kernel-manifest.json
+    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" ios/Tidepool/Supporting/shell-app-manifest.json
+    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" ios/Tidepool/Supporting/EXShell.json
+    sed -i '' "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+else
+    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+fi
 cat ios/Tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -3,19 +3,20 @@
 set -o nounset
 
 # Update manifests to use specified release channel rather than default
-pwd # remove this later, just testing Travis CI
 
-if [ "$(uname)" == "Darwin" ]; then
-    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" android/app/src/main/assets/shell-app-manifest.json
-    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" android/app/src/main/assets/kernel-manifest.json
-    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" ios/Tidepool/Supporting/shell-app-manifest.json
-    sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" ios/Tidepool/Supporting/EXShell.json
-    sed -i '' "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
-else
-    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
-    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
-    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
-    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
-    sed -i "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
-fi
+target_file=android/app/src/main/assets/shell-app-manifest.json
+sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+
+target_file=android/app/src/main/assets/kernel-manifest.json
+sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+
+target_file=ios/Tidepool/Supporting/shell-app-manifest.json
+sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+
+target_file=ios/Tidepool/Supporting/EXShell.json
+sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+
+target_file=ios/Tidepool/Supporting/EXShell.plist
+sed -e "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+
 cat ios/Tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
+set -o nounset
+
 # Update manifests to use specified release channel rather than default
-pwd
-sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/shell-app-manifest.json
-sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/kernel-manifest.json
-sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/shell-app-manifest.json
-sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/EXShell.json
-sed -i '.bak' "s/\<string\>default\<\/string\>/\<string\>$1\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+pwd # remove this later, just testing Travis CI
+sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/shell-app-manifest.json
+sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/kernel-manifest.json
+sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/shell-app-manifest.json
+sed -i .bak "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/EXShell.json
+sed -i .bak "s/\<string\>default\<\/string\>/\<string\>$1\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+cat ios/Tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Update manifests to use specified release channel rather than default
-sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/shell-app-manifest.json
-sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/kernel-manifest.json
-sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/shell-app-manifest.json
-sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/EXShell.json
-sed -i '' "s/\<string\>default\<\/string\>/\<string\>$1\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist
+pwd
+sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/shell-app-manifest.json
+sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/kernel-manifest.json
+sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/shell-app-manifest.json
+sed -i '.bak' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/EXShell.json
+sed -i '.bak' "s/\<string\>default\<\/string\>/\<string\>$1\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -2,21 +2,24 @@
 
 set -o nounset
 
-# Update manifests to use specified release channel rather than default
+updateReleaseChannel() {
+    sed -e "$expression" "$target_file" > "$target_file.bak" && mv "$target_file.bak" "$target_file"
+}
 
-target_file=android/app/src/main/assets/shell-app-manifest.json
-sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+releaseChannel=$1
 
-target_file=android/app/src/main/assets/kernel-manifest.json
-sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+expression="s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$releaseChannel"\"/"
+target_file="android/app/src/main/assets/shell-app-manifest.json"
+updateReleaseChannel
+target_file="android/app/src/main/assets/kernel-manifest.json"
+updateReleaseChannel
+target_file="ios/Tidepool/Supporting/shell-app-manifest.json"
+updateReleaseChannel
+target_file="ios/Tidepool/Supporting/EXShell.json"
+updateReleaseChannel
 
-target_file=ios/Tidepool/Supporting/shell-app-manifest.json
-sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
-
-target_file=ios/Tidepool/Supporting/EXShell.json
-sed -e "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\""$1"\"/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
-
-target_file=ios/Tidepool/Supporting/EXShell.plist
-sed -e "s/\<string\>default\<\/string\>/\<string\>"$1"\<\/string\>/" "$target_file" > "$target_file.$$" && mv "$target_file.$$" "$target_file"
+expression="s/\<string\>default\<\/string\>/\<string\>"$releaseChannel"\<\/string\>/"
+target_file="ios/Tidepool/Supporting/EXShell.plist"
+updateReleaseChannel
 
 cat ios/Tidepool/Supporting/EXShell.plist # remove this later, just testing Travis CI

--- a/scripts/update-release-channel.sh
+++ b/scripts/update-release-channel.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Update manifests to use specified release channel rather than default
+sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/shell-app-manifest.json
+sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" android/app/src/main/assets/kernel-manifest.json
+sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/shell-app-manifest.json
+sed -i '' "s/\"releaseChannel\"\:\"default\"/\"releaseChannel\"\:\"$1\"/" ios/Tidepool/Supporting/EXShell.json
+sed -i '' "s/\<string\>default\<\/string\>/\<string\>$1\<\/string\>/" ios/Tidepool/Supporting/EXShell.plist


### PR DESCRIPTION
Disable auto-updating of JS bundle for Android
- Remove generated/AppConstants.java from .gitignore
- Update AppConstants.java to set ARE_REMOTE_UPDATES_ENABLED to false (similar to areRemoteUpdatesEnabled in EXShell.plist for iOS, which was already correct). Also make sure the JS bundle for Android is using the correct Expo version (32 instead of 31).

NOTE: AppConstants.java is initially generated when ejecting to ExpoKit, and is then updated during builds, but, not all app.json properties are reflected to the already initially generated AppConstants.java file, which seems like an Expo bug. (We already did have updates disabled in app.json.) After initial ejection it seems only the embedded response for the embedded JS bundle is updated. This happens during 'expo publish'. That published JS bundle is then embedded as a resource in the app. With this change, the Android app (like iOS) should no longer try to auto-update to JS bundles published after the .apk build completed and the JS bundle was embedded in that .apk.

See: https://trello.com/c/sYiATRO0