### PR TITLE
Fix first time tips issue (https://trello.com/c/iIXjbmDN)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
 
   <application
     android:name=".MainApplication"
-    android:allowBackup="true"
+    android:allowBackup="false"
     android:icon="@mipmap/ic_launcher"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:label="@string/app_name"


### PR DESCRIPTION
Fix issue where first time tips were not resetting after uninstall/reinstall for Android

- Turn off allowBackup. This regressed as part of the Expo 31 upgrade back in January. See commit a6ce81e47460fb7e689bfc0843f19df3cf473e53

See: https://trello.com/c/iIXjbmDN