### PR TITLE
[RN] Performance: Use cached graph and comment data by default when toggling a note, show new data when loaded

### DIFF
--- a/src/actions/graphDataFetch.js
+++ b/src/actions/graphDataFetch.js
@@ -1,4 +1,5 @@
 import api from "../api";
+import ConnectionStatus from "../models/ConnectionStatus";
 
 const GRAPH_DATA_FETCH_DID_START = "GRAPH_DATA_FETCH_DID_START";
 const GRAPH_DATA_FETCH_DID_SUCCEED = "GRAPH_DATA_FETCH_DID_SUCCEED";
@@ -32,9 +33,7 @@ const graphDataFetchAsync = ({
   lowBGBoundary,
   highBGBoundary,
 }) => async dispatch => {
-  dispatch(graphDataFetchDidStart({ messageId }));
-
-  const { graphData, errorMessage } = await api().fetchGraphDataAsync({
+  const fetchParams = {
     userId,
     messageId,
     noteDate,
@@ -43,12 +42,32 @@ const graphDataFetchAsync = ({
     objectTypes,
     lowBGBoundary,
     highBGBoundary,
-  });
+  };
+  const { graphData: offlineGraphData, isAvailableOffline } = await api().fetchGraphDataAsync(
+    fetchParams,
+    true // fetchOnlyFromCache
+  );
 
-  if (errorMessage) {
-    dispatch(graphDataFetchDidFail({ messageId, errorMessage }));
-  } else {
-    dispatch(graphDataFetchDidSucceed({ messageId, graphData }));
+  if (isAvailableOffline) {
+    dispatch(
+      graphDataFetchDidSucceed({ messageId, graphData: offlineGraphData })
+    );
+  }
+
+  if (ConnectionStatus.isOnline) {
+    if (!isAvailableOffline) {
+      dispatch(graphDataFetchDidStart({ messageId }));
+    }
+
+    const { graphData, errorMessage } = await api().fetchGraphDataAsync(
+      fetchParams
+    );
+
+    if (errorMessage) {
+      dispatch(graphDataFetchDidFail({ messageId, errorMessage }));
+    } else {
+      dispatch(graphDataFetchDidSucceed({ messageId, graphData }));
+    }
   }
 };
 

--- a/src/api/TidepoolApi.js
+++ b/src/api/TidepoolApi.js
@@ -41,7 +41,7 @@ class TidepoolApi {
     this.tasksInProgress += 1;
 
     const { sessionToken: previousSessionToken } = authUser;
-    const { sessionToken, userId, errorMessage } = await this.refreshToken({
+    const { sessionToken, userId, errorMessage } = await this.refreshTokenPromise({
       sessionToken: previousSessionToken,
     })
       .then(response => ({
@@ -71,7 +71,7 @@ class TidepoolApi {
 
     this.tasksInProgress += 1;
 
-    const { sessionToken, userId, errorMessage } = await this.signIn({
+    const { sessionToken, userId, errorMessage } = await this.signInPromise({
       username,
       password,
     })
@@ -102,7 +102,7 @@ class TidepoolApi {
 
     this.tasksInProgress += 1;
 
-    const { errorMessage, ...rest } = await this.fetchProfile({
+    const { errorMessage, ...rest } = await this.fetchProfilePromise({
       userId,
     })
       .then(response => {
@@ -134,7 +134,7 @@ class TidepoolApi {
 
     this.tasksInProgress += 1;
 
-    const { settings, errorMessage } = await this.fetchProfileSettings({
+    const { errorMessage, ...rest } = await this.fetchProfileSettingsPromise({
       userId,
     })
       .then(response => {
@@ -158,7 +158,7 @@ class TidepoolApi {
       return this.cache.fetchProfileSettingsAsync({ userId });
     }
 
-    return { settings, errorMessage };
+    return {  ...rest, errorMessage };
   }
 
   async fetchNotesAsync({ userId }) {
@@ -168,7 +168,7 @@ class TidepoolApi {
 
     this.tasksInProgress += 1;
 
-    const { notes, errorMessage } = await this.fetchNotes({
+    const { errorMessage, ...rest } = await this.fetchNotesPromise({
       userId,
     })
       .then(response => {
@@ -208,17 +208,17 @@ class TidepoolApi {
       return this.cache.fetchNotesAsync({ userId });
     }
 
-    return { notes, errorMessage };
+    return { ...rest, errorMessage };
   }
 
-  async fetchCommentsAsync({ messageId }) {
-    if (ConnectionStatus.isOffline) {
+  async fetchCommentsAsync({ messageId }, fetchOnlyFromCache = false) {
+    if (fetchOnlyFromCache || ConnectionStatus.isOffline) {
       return this.cache.fetchCommentsAsync({ messageId });
     }
 
     this.tasksInProgress += 1;
 
-    const { comments, errorMessage } = await this.fetchComments({
+    const { errorMessage, ...rest } = await this.fetchCommentsPromise({
       messageId,
     })
       .then(response => {
@@ -241,10 +241,12 @@ class TidepoolApi {
           (comment1, comment2) => comment1.timestamp - comment2.timestamp
         );
 
-        this.cache.saveCommentsAsync({
-          messageId,
-          comments: sortedComments,
-        });
+        if (!fetchOnlyFromCache) {
+          this.cache.saveCommentsAsync({
+            messageId,
+            comments: sortedComments,
+          });
+        }
 
         return { comments: sortedComments, isAvailableOffline: true };
       })
@@ -259,7 +261,7 @@ class TidepoolApi {
       return this.cache.fetchCommentsAsync({ messageId });
     }
 
-    return { comments, errorMessage };
+    return { errorMessage, ...rest };
   }
 
   async fetchViewableUserProfilesAsync({ userId, fullName }) {
@@ -278,7 +280,7 @@ class TidepoolApi {
     const {
       userIds,
       errorMessage: fetchOtherViewableUserIdsErrorMessage,
-    } = await this.fetchOtherViewableUserIds({
+    } = await this.fetchOtherViewableUserIdsPromise({
       userId,
     })
       .then(response => {
@@ -295,7 +297,7 @@ class TidepoolApi {
     // Get profiles for other viewable user ids
     if (!errorMessage) {
       const fetchProfilePromises = userIds.map(fetchProfileUserId =>
-        this.fetchProfile({ userId: fetchProfileUserId })
+        this.fetchProfilePromise({ userId: fetchProfileUserId })
       );
 
       const {
@@ -343,7 +345,7 @@ class TidepoolApi {
   async addNoteAsync({ currentUser, currentProfile, messageText, timestamp }) {
     this.tasksInProgress += 1;
 
-    const { errorMessage, note } = await this.addNote({
+    const { errorMessage, note } = await this.addNotePromise({
       currentUser,
       currentProfile,
       messageText,
@@ -370,7 +372,7 @@ class TidepoolApi {
   async updateNoteAsync({ currentProfile, note }) {
     this.tasksInProgress += 1;
 
-    const { errorMessage } = await this.updateNote({
+    const { errorMessage } = await this.updateNotePromise({
       note,
     })
       .then(() => ({}))
@@ -393,7 +395,7 @@ class TidepoolApi {
     this.tasksInProgress += 1;
 
     const { id } = note;
-    const { errorMessage } = await this.deleteCommentOrNote({
+    const { errorMessage } = await this.deleteCommentOrNotePromise({
       id,
     })
       .then(() => ({}))
@@ -421,7 +423,7 @@ class TidepoolApi {
   }) {
     this.tasksInProgress += 1;
 
-    const { errorMessage, comment } = await this.addComment({
+    const { errorMessage, comment } = await this.addCommentPromise({
       currentUser,
       currentProfile,
       note,
@@ -448,7 +450,7 @@ class TidepoolApi {
   async updateCommentAsync({ note, comment }) {
     this.tasksInProgress += 1;
 
-    const { errorMessage } = await this.updateComment({
+    const { errorMessage } = await this.updateCommentPromise({
       comment,
     })
       .then(() => ({}))
@@ -470,7 +472,7 @@ class TidepoolApi {
     this.tasksInProgress += 1;
 
     const { id } = comment;
-    const { errorMessage } = await this.deleteCommentOrNote({
+    const { errorMessage } = await this.deleteCommentOrNotePromise({
       id,
     })
       .then(() => ({}))
@@ -488,19 +490,22 @@ class TidepoolApi {
     return { errorMessage };
   }
 
-  async fetchGraphDataAsync({
-    userId,
-    messageId,
-    noteDate,
-    startDate,
-    endDate,
-    objectTypes,
-    lowBGBoundary,
-    highBGBoundary,
-  }) {
+  async fetchGraphDataAsync(
+    {
+      userId,
+      messageId,
+      noteDate,
+      startDate,
+      endDate,
+      objectTypes,
+      lowBGBoundary,
+      highBGBoundary,
+    },
+    fetchOnlyFromCache = false
+  ) {
     let result;
 
-    if (ConnectionStatus.isOffline) {
+    if (fetchOnlyFromCache || ConnectionStatus.isOffline) {
       result = await this.cache.fetchGraphDataAsync({
         userId,
         messageId,
@@ -508,7 +513,7 @@ class TidepoolApi {
     } else {
       this.tasksInProgress += 1;
 
-      result = await this.fetchGraphData({
+      result = await this.fetchGraphDataPromise({
         userId,
         noteDate,
         startDate,
@@ -541,14 +546,14 @@ class TidepoolApi {
     }
 
     let graphData;
-    const { responseData, errorMessage, isAvailableOffline } = result;
+    const { responseData, errorMessage } = result;
+    let { isAvailableOffline } = result;
     if (responseData) {
       // console.log({ responseData });
       const noteTimeSeconds = noteDate.getTime() / 1000;
       const startDateSeconds = startDate.getTime() / 1000;
       const endDateSeconds = endDate.getTime() / 1000;
       graphData = new GraphData();
-      graphData.isAvailableOffline = isAvailableOffline;
       graphData.addResponseData(responseData);
       graphData.process({
         eventTimeSeconds: noteTimeSeconds,
@@ -557,25 +562,27 @@ class TidepoolApi {
         highBGBoundary,
       });
 
-      if (ConnectionStatus.isOnline) {
+      if (ConnectionStatus.isOnline && !fetchOnlyFromCache) {
         this.cache.saveGraphDataAsync({
           userId,
           messageId,
           responseData,
         });
-        graphData.isAvailableOffline = true;
+        isAvailableOffline = true;
       }
     } else {
       graphData = new GraphData();
     }
 
-    return { graphData, errorMessage };
+    graphData.isAvailableOffline = isAvailableOffline;
+
+    return { graphData, errorMessage, isAvailableOffline };
   }
 
   async trackMetricAsync({ metric }) {
     this.tasksInProgress += 1;
 
-    const { errorMessage } = await this.trackMetric({
+    const { errorMessage } = await this.trackMetricPromise({
       metric,
     })
       .then(() => ({}))
@@ -589,10 +596,10 @@ class TidepoolApi {
   }
 
   //
-  // Lower-level promise-based methods
+  // Lower-level Promise based methods
   //
 
-  refreshToken({ sessionToken: previousSessionToken }) {
+  refreshTokenPromise({ sessionToken: previousSessionToken }) {
     const method = "get";
     const url = "/auth/login";
     const baseURL = this.baseUrl;
@@ -619,7 +626,7 @@ class TidepoolApi {
           }
         })
         .catch(error => {
-          // console.log(`refreshToken error: ${error}`);
+          // console.log(`refreshTokenPromise error: ${error}`);
           if (
             error.response &&
             (error.response.status === 400 || error.response.status === 401)
@@ -632,7 +639,7 @@ class TidepoolApi {
     });
   }
 
-  signIn({ username, password }) {
+  signInPromise({ username, password }) {
     const method = "post";
     const url = "/auth/login";
     const baseURL = this.baseUrl;
@@ -672,7 +679,7 @@ class TidepoolApi {
     });
   }
 
-  fetchProfile({ userId }) {
+  fetchProfilePromise({ userId }) {
     const method = "get";
     const url = `/metadata/${userId}/profile`;
     const baseURL = this.baseUrl;
@@ -689,7 +696,7 @@ class TidepoolApi {
     });
   }
 
-  fetchProfileSettings({ userId }) {
+  fetchProfileSettingsPromise({ userId }) {
     const method = "get";
     const url = `/metadata/${userId}/settings`;
     const baseURL = this.baseUrl;
@@ -725,7 +732,7 @@ class TidepoolApi {
     });
   }
 
-  fetchNotes({ userId }) {
+  fetchNotesPromise({ userId }) {
     const method = "get";
     const url = `/message/notes/${userId}`;
     const baseURL = this.baseUrl;
@@ -740,7 +747,7 @@ class TidepoolApi {
         .catch(error => {
           if (error.response && error.response.status === 404) {
             // console.log(
-            //   `fetchNotes: No notes retrieved, status code: ${
+            //   `fetchNotesPromise: No notes retrieved, status code: ${
             //     error.response.status
             //   }, userid: ${userId}`
             // );
@@ -752,7 +759,7 @@ class TidepoolApi {
     });
   }
 
-  fetchComments({ messageId }) {
+  fetchCommentsPromise({ messageId }) {
     const method = "get";
     const url = `/message/thread/${messageId}`;
     const baseURL = this.baseUrl;
@@ -770,7 +777,7 @@ class TidepoolApi {
     });
   }
 
-  fetchOtherViewableUserIds({ userId }) {
+  fetchOtherViewableUserIdsPromise({ userId }) {
     const method = "get";
     const url = `/access/groups/${userId}`;
     const baseURL = this.baseUrl;
@@ -795,7 +802,7 @@ class TidepoolApi {
     });
   }
 
-  addNote({ currentUser, currentProfile, messageText, timestamp }) {
+  addNotePromise({ currentUser, currentProfile, messageText, timestamp }) {
     const method = "post";
     const groupId = currentProfile.userId;
     const url = `/message/send/${groupId}`;
@@ -832,7 +839,7 @@ class TidepoolApi {
     });
   }
 
-  updateNote({ note }) {
+  updateNotePromise({ note }) {
     const method = "put";
     const url = `/message/edit/${note.id}`;
     const baseURL = this.baseUrl;
@@ -855,7 +862,7 @@ class TidepoolApi {
     });
   }
 
-  addComment({ currentUser, currentProfile, note, messageText, timestamp }) {
+  addCommentPromise({ currentUser, currentProfile, note, messageText, timestamp }) {
     const method = "post";
     const groupId = currentProfile.userId;
     const url = `/message/reply/${note.id}`;
@@ -892,7 +899,7 @@ class TidepoolApi {
     });
   }
 
-  updateComment({ comment }) {
+  updateCommentPromise({ comment }) {
     const method = "put";
     const url = `/message/edit/${comment.id}`;
     const baseURL = this.baseUrl;
@@ -915,7 +922,7 @@ class TidepoolApi {
     });
   }
 
-  deleteCommentOrNote({ id }) {
+  deleteCommentOrNotePromise({ id }) {
     const method = "delete";
     const url = `/message/remove/${id}`;
     const baseURL = this.baseUrl;
@@ -932,7 +939,7 @@ class TidepoolApi {
     });
   }
 
-  fetchGraphData({ userId, startDate, endDate, objectTypes }) {
+  fetchGraphDataPromise({ userId, startDate, endDate, objectTypes }) {
     const method = "get";
     const url = `/data/${userId}`;
     const params = {
@@ -990,7 +997,7 @@ class TidepoolApi {
     });
   }
 
-  trackMetric({ metric }) {
+  trackMetricPromise({ metric }) {
     const method = "get";
     const url = `/metrics/thisuser/tidepool-${metric}`;
     const baseURL = this.baseUrl;
@@ -1011,11 +1018,11 @@ class TidepoolApi {
     return new Promise((resolve, reject) => {
       axios({ method, url, baseURL, headers, params, timeout })
         .then(() => {
-          // console.log(`trackMetric succeeded with metric: ${metric}`);
+          // console.log(`trackMetricPromise succeeded with metric: ${metric}`);
           resolve();
         })
         .catch(error => {
-          // console.log(`trackMetric error: ${error}, with metric: ${metric}`);
+          // console.log(`trackMetricPromise error: ${error}, with metric: ${metric}`);
           reject(error);
         });
     });

--- a/src/models/Metrics.js
+++ b/src/models/Metrics.js
@@ -43,7 +43,7 @@ class Metrics {
       // console.log(`processNextMetric: ${metric}`);
 
       api()
-        .trackMetric({
+        .trackMetricPromise({
           metric,
         })
         .then(() => {


### PR DESCRIPTION
[RN] Performance: Use cached graph and comment data by default when toggling a note, show new data when loaded

- When loading comments and graph data when online, first attempt to load from cache, showing that data immediately if available. If user is online and the data is available from cache, don't show the loading indicator (don't call the didStart action creator methods) but go ahead and also kick off a refresh via async TidepoolApi call. If user is online and data is unavailable from the cache, show the loading indicator (via didStart action creator methods) and load the data via the async Tidepool api call.
- Rename internal lower level promise-based TidepoolApi methods for clarity, to distinguish from higher level async methods

See https://tidepool.atlassian.net/browse/MOBILE-120