### PR TITLE
MOBILE-124: Opening notes the cached data is displayed, but the note is not dynamically updating

### DIFF
--- a/src/components/NotesList.js
+++ b/src/components/NotesList.js
@@ -32,14 +32,14 @@ class NotesList extends PureComponent {
   componentDidMount() {
     const { errorMessage } = this.props;
     if (errorMessage) {
-      AlertManager.showErrorAlert(errorMessage);
+      AlertManager.showError(errorMessage);
     }
   }
 
   componentWillReceiveProps(nextProps) {
     const { errorMessage, fetching } = this.props;
     if (nextProps.errorMessage && !errorMessage) {
-      AlertManager.showErrorAlert(nextProps.errorMessage);
+      AlertManager.showError(nextProps.errorMessage);
     }
 
     if (!nextProps.fetching && fetching) {

--- a/src/components/NotesListItem.js
+++ b/src/components/NotesListItem.js
@@ -68,11 +68,11 @@ class NotesListItem extends PureComponent {
     }
 
     if (commentsFetchErrorMessage) {
-      AlertManager.showErrorAlert(commentsFetchErrorMessage);
+      AlertManager.showError(commentsFetchErrorMessage);
     }
 
     if (graphDataFetchErrorMessage) {
-      AlertManager.showErrorAlert(graphDataFetchErrorMessage);
+      AlertManager.showError(graphDataFetchErrorMessage);
     }
 
     SignificantTimeChangeNotification.subscribe(this.timeChanged);
@@ -100,7 +100,7 @@ class NotesListItem extends PureComponent {
       shouldShowCommentsFetchErrorMessage ||
       shouldShowGraphDataFetchErrorMessage
     ) {
-      AlertManager.showErrorAlert(
+      AlertManager.showError(
         nextProps.commentsFetchData.errorMessage ||
           nextProps.graphDataFetchData.errorMessage
       );

--- a/src/components/ProfileList.js
+++ b/src/components/ProfileList.js
@@ -18,14 +18,14 @@ class ProfileList extends PureComponent {
   componentDidMount() {
     const { errorMessage } = this.props;
     if (errorMessage) {
-      AlertManager.showErrorAlert(errorMessage);
+      AlertManager.showError(errorMessage);
     }
   }
 
   componentWillReceiveProps(nextProps) {
     const { errorMessage, fetching } = this.props;
     if (nextProps.errorMessage && !errorMessage) {
-      AlertManager.showErrorAlert(nextProps.errorMessage);
+      AlertManager.showError(nextProps.errorMessage);
     }
 
     if (!nextProps.fetching && fetching) {

--- a/src/screens/AddOrEditCommentScreen.js
+++ b/src/screens/AddOrEditCommentScreen.js
@@ -105,7 +105,7 @@ class AddOrEditCommentScreen extends PureComponent {
     }
 
     if (commentsFetchData.errorMessage || graphDataFetchData.errorMessage) {
-      AlertManager.showErrorAlert(
+      AlertManager.showError(
         commentsFetchData.errorMessage || graphDataFetchData.errorMessage
       );
     }
@@ -129,7 +129,7 @@ class AddOrEditCommentScreen extends PureComponent {
       nextProps.graphDataFetchData.errorMessage &&
       !graphDataFetchData.errorMessage;
     if (shouldShowCommentsFetchError || shouldShowGraphDataFetchError) {
-      AlertManager.showErrorAlert(
+      AlertManager.showError(
         nextProps.commentsFetchData.errorMessage ||
           nextProps.graphDataFetchData.errorMessage
       );


### PR DESCRIPTION
Note. This PR includes both the fix for not showing timeout errors for Tidepool API calls as well as a root cause fix for the graph not re-rendering with new graph data, after first having shown cached graph data, when the new graph data succeeds.