### PR TITLE
MOBILE-159: Changes made in 3.1.2 (64700) prevent RN Android app from launching

### DIFF
--- a/android/app/src/main/java/host/exp/exponent/TPNativeModule.java
+++ b/android/app/src/main/java/host/exp/exponent/TPNativeModule.java
@@ -24,7 +24,8 @@ public class TPNativeModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void setUser(String userId, String username, String userFullName, boolean isDSAUser) {
+  public void setUser(String userId, String username, String userFullName, boolean isDSAUser, String sessionToken) {
+    // NOTE: sessionToken is not currently needed on Android native side of bridge. iOS does need it, though, for Health data uploading
     MainApplication application = (MainApplication) (this.getReactApplicationContext().getApplicationContext());
     application.setUser(userId, username, userFullName, isDSAUser);
   }


### PR DESCRIPTION
MOBILE-159: Changes made in 3.1.2 (64700) prevent RN Android app from launching
- Add missing/expected sessionToken parameter to setUser on the Android native side of TPNativeModule bridge