### PR TITLE
MOBILE-171 Split upload process into two phases to workaround backend performance issues getting data set / upload id

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -63,7 +63,7 @@ target 'Tidepool' do
   pod 'RollbarReactNative', :path => '../node_modules/rollbar-react-native'
   pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'
 
-  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '0.9.9'
+  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '1.0.0'
   pod 'SwiftyJSON', '5.0.0'
   pod 'CocoaLumberjack/Swift', '3.5.3'
   pod 'Alamofire', '4.9.1'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -374,7 +374,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RollbarReactNative (from `../node_modules/rollbar-react-native`)
   - SwiftyJSON (= 5.0.0)
-  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `0.9.9`)
+  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `1.0.0`)
   - UMBarCodeScannerInterface (from `../node_modules/unimodules-barcode-scanner-interface/ios`)
   - UMCameraInterface (from `../node_modules/unimodules-camera-interface/ios`)
   - UMConstantsInterface (from `../node_modules/unimodules-constants-interface/ios`)
@@ -502,7 +502,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/rollbar-react-native"
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 0.9.9
+    :tag: 1.0.0
   UMBarCodeScannerInterface:
     :path: !ruby/object:Pathname
     path: "../node_modules/unimodules-barcode-scanner-interface/ios"
@@ -548,7 +548,7 @@ CHECKOUT OPTIONS:
     :tag: ios/2.14.2
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 0.9.9
+    :tag: 1.0.0
 
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
@@ -618,6 +618,6 @@ SPEC CHECKSUMS:
   UMTaskManagerInterface: a98e37a576a5220bf43b8faf33cfdc129d2f441d
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
 
-PODFILE CHECKSUM: 28f8306977462125e49241a547ecf12adbc56993
+PODFILE CHECKSUM: 2002996259284225ea98622e62fdf10e9b1d9f23
 
 COCOAPODS: 1.8.4

--- a/src/App/AppWithNavigationState.js
+++ b/src/App/AppWithNavigationState.js
@@ -35,8 +35,8 @@ class AppWithNavigationState extends PureComponent {
         ...TPNativeHealth.healthKitInterfaceConfiguration,
         turnOffUploaderReason: TPNativeHealth.turnOffUploaderReason,
         turnOffUploaderError: TPNativeHealth.turnOffUploaderError,
-        isPendingUploadHistorical:
-          TPNativeHealth.isPendingUploadHistorical,
+        isHistoricalUploadPending:
+          TPNativeHealth.isHistoricalUploadPending,
         isUploadingHistorical: TPNativeHealth.isUploadingHistorical,
         historicalUploadCurrentDay: TPNativeHealth.historicalUploadCurrentDay,
         historicalUploadTotalDays: TPNativeHealth.historicalUploadTotalDays,
@@ -61,8 +61,8 @@ class AppWithNavigationState extends PureComponent {
           ...TPNativeHealth.healthKitInterfaceConfiguration,
           turnOffUploaderReason: TPNativeHealth.turnOffUploaderReason,
           turnOffUploaderError: TPNativeHealth.turnOffUploaderError,
-          isPendingUploadHistorical:
-            TPNativeHealth.isPendingUploadHistorical,
+          isHistoricalUploadPending:
+            TPNativeHealth.isHistoricalUploadPending,
           isUploadingHistorical: TPNativeHealth.isUploadingHistorical,
           historicalUploadCurrentDay: TPNativeHealth.historicalUploadCurrentDay,
           historicalUploadTotalDays: TPNativeHealth.historicalUploadTotalDays,
@@ -78,8 +78,8 @@ class AppWithNavigationState extends PureComponent {
         healthStateSet({
           turnOffUploaderReason: TPNativeHealth.turnOffUploaderReason,
           turnOffUploaderError: TPNativeHealth.turnOffUploaderError,
-          isPendingUploadHistorical:
-            TPNativeHealth.isPendingUploadHistorical,
+          isHistoricalUploadPending:
+            TPNativeHealth.isHistoricalUploadPending,
           isUploadingHistorical: TPNativeHealth.isUploadingHistorical,
           historicalUploadCurrentDay: TPNativeHealth.historicalUploadCurrentDay,
           historicalUploadTotalDays: TPNativeHealth.historicalUploadTotalDays,
@@ -94,8 +94,8 @@ class AppWithNavigationState extends PureComponent {
           healthStateSet({
             turnOffUploaderReason: TPNativeHealth.turnOffUploaderReason,
             turnOffUploaderError: TPNativeHealth.turnOffUploaderError,
-            isPendingUploadHistorical:
-              TPNativeHealth.isPendingUploadHistorical,
+            isHistoricalUploadPending:
+              TPNativeHealth.isHistoricalUploadPending,
             isUploadingHistorical: TPNativeHealth.isUploadingHistorical,
             historicalUploadCurrentDay:
               TPNativeHealth.historicalUploadCurrentDay,

--- a/src/actions/health.js
+++ b/src/actions/health.js
@@ -1,45 +1,8 @@
-import { TPNativeHealth } from "../models/TPNativeHealth";
-
 const HEALTH_STATE_SET = "HEALTH_STATE_SET";
 
-/* eslint-disable no-param-reassign */
-// TODO: Revisit this. This is kind of a hack. This action creator side effect
-// to start upload, if pending, is calculated based on payload and current
-// state, and is "transient" / "auto-resetting" ... we should revisit this with
-// a more elegant approach
-const startUploadingSideEffect = (payload, state) => {
-  const isTurningInterfaceOn =
-    payload.isTurningInterfaceOn || state.health.isTurningInterfaceOn;
-  const isInterfaceOn = payload.isInterfaceOn || state.health.isInterfaceOn;
-  const isPendingUploadHistorical =
-    payload.isPendingUploadHistorical || state.health.isPendingUploadHistorical;
-  const isUploadingHistorical =
-    payload.isUploadingHistorical || state.health.isUploadingHistorical;
-  if (
-    payload.isPendingUploadHistorical &&
-    !isInterfaceOn &&
-    !isTurningInterfaceOn
-  ) {
-    payload.isPendingUploadHistorical = false;
-  } else if (isUploadingHistorical) {
-    payload.isPendingUploadHistorical = false;
-  } else if (isInterfaceOn && isPendingUploadHistorical) {
-    TPNativeHealth.stopUploadingHistoricalAndReset(); // Reset uploader state so historical upload starts from beginning
-    TPNativeHealth.startUploadingHistorical();
-    payload.isPendingUploadHistorical = false; // Reset isPendingUploadHistorical since it is "transient" / "auto-resetting"
-  }
-};
-/* eslint-enable no-param-reassign */
-
-/* eslint-disable no-param-reassign */
-const healthStateSet = payload => async (dispatch, getState) => {
-  startUploadingSideEffect(payload, getState());
-
-  dispatch({
-    type: HEALTH_STATE_SET,
-    payload,
-  });
-};
-/* eslint-enable no-param-reassign */
+const healthStateSet = payload => ({
+  type: HEALTH_STATE_SET,
+  payload,
+});
 
 export { healthStateSet, HEALTH_STATE_SET };

--- a/src/models/TPNativeHealth.js
+++ b/src/models/TPNativeHealth.js
@@ -14,7 +14,7 @@ class TPNativeHealthSingletonClass {
       isInterfaceOn: false,
     };
 
-    this.isPendingUploadHistorical = false;
+    this.isHistoricalUploadPending = false;
     this.isUploadingHistorical = false;
     this.historicalUploadCurrentDay = 0;
     this.historicalUploadTotalDays = 0;
@@ -82,18 +82,12 @@ class TPNativeHealthSingletonClass {
     }
   }
 
-  startPendingUploadHistorical() {
-    this.isPendingUploadHistorical = true;
-  }
-
   startUploadingHistorical() {
     try {
-      this.isPendingUploadHistorical = false;
       this.historicalUploadCurrentDay = 0;
       this.historicalUploadTotalDays = 0;
       this.turnOffUploaderReason = "";
       this.turnOffUploaderError = "";
-      this.notify("onUploadStatsUpdated", "historical");
       this.nativeModule.startUploadingHistorical();
     } catch (error) {
       // console.log(`error: ${error}`);
@@ -102,7 +96,6 @@ class TPNativeHealthSingletonClass {
 
   stopUploadingHistoricalAndReset() {
     try {
-      this.isPendingUploadHistorical = false;
       this.nativeModule.stopUploadingHistoricalAndReset();
     } catch (error) {
       // console.log(`error: ${error}`);
@@ -115,7 +108,7 @@ class TPNativeHealthSingletonClass {
   };
 
   onTurnOnHistoricalUpload = () => {
-    this.isPendingUploadHistorical = false;
+    this.isHistoricalUploadPending = false;
     this.isUploadingHistorical = true;
     this.turnOffUploaderReason = "";
     this.turnOffUploaderError = "";
@@ -123,7 +116,7 @@ class TPNativeHealthSingletonClass {
   };
 
   onTurnOffHistoricalUpload = params => {
-    this.isPendingUploadHistorical = false;
+    this.isHistoricalUploadPending = false;
     this.turnOffUploaderReason = params.turnOffUploaderReason;
     let error = params.turnOffUploaderError;
     const errorPrefix = "error: ";
@@ -139,9 +132,7 @@ class TPNativeHealthSingletonClass {
   onUploadStatsUpdated = params => {
     if (params.type === "historical") {
       this.isUploadingHistorical = params.isUploadingHistorical;
-      if (this.isUploadingHistorical) {
-        this.isPendingUploadHistorical = false;
-      }
+      this.isHistoricalUploadPending = params.isHistoricalUploadPending;
       this.historicalUploadCurrentDay = params.historicalUploadCurrentDay;
       this.historicalUploadTotalDays = params.historicalUploadTotalDays;
       this.updateHistoricalUploadCurrentDayIfComplete();

--- a/src/reducers/health.js
+++ b/src/reducers/health.js
@@ -10,7 +10,7 @@ const initialState = {
   interfaceTurnedOffError: "",
   isTurningInterfaceOn: false,
   isInterfaceOn: false,
-  isPendingUploadHistorical: false,
+  isHistoricalUploadPending: false,
   isUploadingHistorical: false,
   historicalUploadCurrentDay: 0,
   historicalUploadTotalDays: 0,

--- a/src/screens/HealthSyncScreen.js
+++ b/src/screens/HealthSyncScreen.js
@@ -100,7 +100,7 @@ class HealthSyncScreen extends PureComponent {
   componentDidMount() {
     const {
       healthStateSet,
-      health: { isUploadingHistorical, isPendingUploadHistorical },
+      health: { isUploadingHistorical, isHistoricalUploadPending },
     } = this.props;
 
     TPNativeHealth.setHasPresentedSyncUI();
@@ -108,7 +108,7 @@ class HealthSyncScreen extends PureComponent {
       hasPresentedSyncUI: true,
     });
 
-    if (isUploadingHistorical || isPendingUploadHistorical) {
+    if (isUploadingHistorical || isHistoricalUploadPending) {
       this.setState({
         shouldShowSyncStatus: true,
       });
@@ -118,10 +118,10 @@ class HealthSyncScreen extends PureComponent {
   /* eslint-disable react/no-did-update-set-state */
   componentDidUpdate() {
     const {
-      health: { isUploadingHistorical, isPendingUploadHistorical },
+      health: { isUploadingHistorical, isHistoricalUploadPending },
     } = this.props;
 
-    if (isUploadingHistorical || isPendingUploadHistorical) {
+    if (isUploadingHistorical || isHistoricalUploadPending) {
       this.setState({
         shouldShowSyncStatus: true,
       });
@@ -132,10 +132,10 @@ class HealthSyncScreen extends PureComponent {
   onPressCancelOrContinue = () => {
     const {
       navigateGoBack,
-      health: { isUploadingHistorical, isPendingUploadHistorical },
+      health: { isUploadingHistorical, isHistoricalUploadPending },
     } = this.props;
 
-    if (isUploadingHistorical || isPendingUploadHistorical) {
+    if (isUploadingHistorical || isHistoricalUploadPending) {
       Alert.alert("Stop Syncing?", null, [
         {
           text: "Cancel",
@@ -157,11 +157,8 @@ class HealthSyncScreen extends PureComponent {
   // TODO: uploader - if the interface is off, and not turning on, then we
   // failed to prepare upload (didn't get upload id), ideally we should retry
   onPressSync = () => {
-    const { healthStateSet } = this.props;
-
-    healthStateSet({
-      isPendingUploadHistorical: true,
-    });
+    TPNativeHealth.stopUploadingHistoricalAndReset();
+    TPNativeHealth.startUploadingHistorical();
 
     this.setState({
       shouldShowSyncStatus: true,


### PR DESCRIPTION
Improve the robustness of pending upload handling:
- Let TPNativeHealth (native side of bridge) handle the pending start of the upload
- Remove the redux side effect state hack from actions/health.js
- Continue to reflect isHistoricalUploadPending via events to the JS side of bridge so UI can react appropriately