### PR TITLE
MOBILE-185, MOBILE-182, MOBILE-177, MOBILE-183

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -63,7 +63,7 @@ target 'Tidepool' do
   pod 'RollbarReactNative', :path => '../node_modules/rollbar-react-native'
   pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'
 
-  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '1.0.5'
+  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '1.0.6'
   pod 'SwiftyJSON', '5.0.0'
   pod 'CocoaLumberjack/Swift', '3.5.3'
   pod 'Alamofire', '4.9.1'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -63,7 +63,7 @@ target 'Tidepool' do
   pod 'RollbarReactNative', :path => '../node_modules/rollbar-react-native'
   pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'
 
-  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '1.0.3'
+  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '1.0.5'
   pod 'SwiftyJSON', '5.0.0'
   pod 'CocoaLumberjack/Swift', '3.5.3'
   pod 'Alamofire', '4.9.1'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -375,7 +375,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RollbarReactNative (from `../node_modules/rollbar-react-native`)
   - SwiftyJSON (= 5.0.0)
-  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `1.0.3`)
+  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `1.0.5`)
   - UMBarCodeScannerInterface (from `../node_modules/unimodules-barcode-scanner-interface/ios`)
   - UMCameraInterface (from `../node_modules/unimodules-camera-interface/ios`)
   - UMConstantsInterface (from `../node_modules/unimodules-constants-interface/ios`)
@@ -505,7 +505,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/rollbar-react-native"
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 1.0.3
+    :tag: 1.0.5
   UMBarCodeScannerInterface:
     :path: !ruby/object:Pathname
     path: "../node_modules/unimodules-barcode-scanner-interface/ios"
@@ -551,7 +551,7 @@ CHECKOUT OPTIONS:
     :tag: ios/2.14.2
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 1.0.3
+    :tag: 1.0.5
 
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
@@ -622,6 +622,6 @@ SPEC CHECKSUMS:
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
   Zip: 8877eede3dda76bcac281225c20e71c25270774c
 
-PODFILE CHECKSUM: 8fe29bd14c71aa3c3cef265ae97b6f2d376b5e11
+PODFILE CHECKSUM: 975295113361793d057795ff5432c0a44034af0a
 
 COCOAPODS: 1.8.4

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -375,7 +375,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RollbarReactNative (from `../node_modules/rollbar-react-native`)
   - SwiftyJSON (= 5.0.0)
-  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `1.0.5`)
+  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `1.0.6`)
   - UMBarCodeScannerInterface (from `../node_modules/unimodules-barcode-scanner-interface/ios`)
   - UMCameraInterface (from `../node_modules/unimodules-camera-interface/ios`)
   - UMConstantsInterface (from `../node_modules/unimodules-constants-interface/ios`)
@@ -505,7 +505,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/rollbar-react-native"
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 1.0.5
+    :tag: 1.0.6
   UMBarCodeScannerInterface:
     :path: !ruby/object:Pathname
     path: "../node_modules/unimodules-barcode-scanner-interface/ios"
@@ -551,7 +551,7 @@ CHECKOUT OPTIONS:
     :tag: ios/2.14.2
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 1.0.5
+    :tag: 1.0.6
 
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
@@ -622,6 +622,6 @@ SPEC CHECKSUMS:
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
   Zip: 8877eede3dda76bcac281225c20e71c25270774c
 
-PODFILE CHECKSUM: 975295113361793d057795ff5432c0a44034af0a
+PODFILE CHECKSUM: 1d0616389b0603651d65f18bcf7facac8b866e2a
 
 COCOAPODS: 1.8.4

--- a/ios/Tidepool/TPNativeHealthBridge.m
+++ b/ios/Tidepool/TPNativeHealthBridge.m
@@ -34,6 +34,7 @@ RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(setUploaderIncludeCFNetworkDiagnostics: 
 
 RCT_EXTERN_METHOD(startUploadingHistorical)
 RCT_EXTERN_METHOD(stopUploadingHistoricalAndReset)
+RCT_EXTERN_METHOD(resetCurrentUploader)
 
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(uploaderProgress)
 

--- a/src/App/AppWithNavigationState.js
+++ b/src/App/AppWithNavigationState.js
@@ -30,6 +30,7 @@ class AppWithNavigationState extends PureComponent {
     BackHandler.addEventListener("hardwareBackPress", this.onBackPress);
     TPNative.addListener(this.onNativeEvent);
     TPNativeHealth.addListener(this.onNativeHealthEvent);
+    TPNativeHealth.refreshUploadStats();
 
     // Do initial dispatch of health state when mounting. Further updates are by way of TPNativeHealth events
     dispatch(
@@ -40,13 +41,18 @@ class AppWithNavigationState extends PureComponent {
         isHistoricalUploadPending: TPNativeHealth.isHistoricalUploadPending,
         isUploadingHistoricalRetry: TPNativeHealth.isUploadingHistoricalRetry,
         historicalUploadLimitsIndex: TPNativeHealth.historicalUploadLimitsIndex,
-        historicalUploadMaxLimitsIndex: TPNativeHealth.historicalUploadMaxLimitsIndex,
+        historicalUploadMaxLimitsIndex:
+          TPNativeHealth.historicalUploadMaxLimitsIndex,
         historicalUploadCurrentDay: TPNativeHealth.historicalUploadCurrentDay,
         historicalUploadTotalDays: TPNativeHealth.historicalUploadTotalDays,
-        historicalUploadTotalSamples: TPNativeHealth.historicalUploadTotalSamples,
-        historicalUploadTotalDeletes: TPNativeHealth.historicalUploadTotalDeletes,
-        turnOffHistoricalUploaderReason: TPNativeHealth.turnOffHistoricalUploaderReason,
-        turnOffHistoricalUploaderError: TPNativeHealth.turnOffHistoricalUploaderError,
+        historicalUploadTotalSamples:
+          TPNativeHealth.historicalUploadTotalSamples,
+        historicalUploadTotalDeletes:
+          TPNativeHealth.historicalUploadTotalDeletes,
+        turnOffHistoricalUploaderReason:
+          TPNativeHealth.turnOffHistoricalUploaderReason,
+        turnOffHistoricalUploaderError:
+          TPNativeHealth.turnOffHistoricalUploaderError,
 
         isUploadingCurrent: TPNativeHealth.isUploadingCurrent,
         isUploadingCurrentRetry: TPNativeHealth.isUploadingCurrentRetry,
@@ -54,9 +60,11 @@ class AppWithNavigationState extends PureComponent {
         currentUploadMaxLimitsIndex: TPNativeHealth.currentUploadMaxLimitsIndex,
         currentUploadTotalSamples: TPNativeHealth.currentUploadTotalSamples,
         currentUploadTotalDeletes: TPNativeHealth.currentUploadTotalDeletes,
-        turnOffCurrentUploaderReason: TPNativeHealth.turnOffCurrentUploaderReason,
+        turnOffCurrentUploaderReason:
+          TPNativeHealth.turnOffCurrentUploaderReason,
         turnOffCurrentUploaderError: TPNativeHealth.turnOffCurrentUploaderError,
-        lastCurrentUploadUiDescription: TPNativeHealth.lastCurrentUploadUiDescription,
+        lastCurrentUploadUiDescription:
+          TPNativeHealth.lastCurrentUploadUiDescription,
       })
     );
   }
@@ -68,12 +76,12 @@ class AppWithNavigationState extends PureComponent {
     TPNativeHealth.removeListener(this.onNativeHealthEvent);
   }
 
-  onNativeEvent = (eventName) => {
+  onNativeEvent = eventName => {
     const { dispatch } = this.props;
     if (eventName === "onShareDidEndPreview") {
-      dispatch(navigateDebugSettings())
+      dispatch(navigateDebugSettings());
     }
-  }
+  };
 
   onNativeHealthEvent = (eventName, uploaderType) => {
     const { dispatch } = this.props;
@@ -87,17 +95,24 @@ class AppWithNavigationState extends PureComponent {
           isHistoricalUploadPending: TPNativeHealth.isHistoricalUploadPending,
           historicalUploadCurrentDay: TPNativeHealth.historicalUploadCurrentDay,
           historicalUploadTotalDays: TPNativeHealth.historicalUploadTotalDays,
-          historicalUploadTotalSamples: TPNativeHealth.historicalUploadTotalSamples,
-          historicalUploadTotalDeletes: TPNativeHealth.historicalUploadTotalDeletes,
-          turnOffHistoricalUploaderReason: TPNativeHealth.turnOffHistoricalUploaderReason,
-          turnOffHistoricalUploaderError: TPNativeHealth.turnOffHistoricalUploaderError,
+          historicalUploadTotalSamples:
+            TPNativeHealth.historicalUploadTotalSamples,
+          historicalUploadTotalDeletes:
+            TPNativeHealth.historicalUploadTotalDeletes,
+          turnOffHistoricalUploaderReason:
+            TPNativeHealth.turnOffHistoricalUploaderReason,
+          turnOffHistoricalUploaderError:
+            TPNativeHealth.turnOffHistoricalUploaderError,
 
           isUploadingCurrent: TPNativeHealth.isUploadingCurrent,
           currentUploadTotalSamples: TPNativeHealth.currentUploadTotalSamples,
           currentUploadTotalDeletes: TPNativeHealth.currentUploadTotalDeletes,
-          turnOffCurrentUploaderReason: TPNativeHealth.turnOffCurrentUploaderReason,
-          turnOffCurrentUploaderError: TPNativeHealth.turnOffCurrentUploaderError,
-          lastCurrentUploadUiDescription: TPNativeHealth.lastCurrentUploadUiDescription,
+          turnOffCurrentUploaderReason:
+            TPNativeHealth.turnOffCurrentUploaderReason,
+          turnOffCurrentUploaderError:
+            TPNativeHealth.turnOffCurrentUploaderError,
+          lastCurrentUploadUiDescription:
+            TPNativeHealth.lastCurrentUploadUiDescription,
         })
       );
     } else if (
@@ -109,28 +124,39 @@ class AppWithNavigationState extends PureComponent {
           healthStateSet({
             isUploadingHistorical: TPNativeHealth.isUploadingHistorical,
             isHistoricalUploadPending: TPNativeHealth.isHistoricalUploadPending,
-            isUploadingHistoricalRetry: TPNativeHealth.isUploadingHistoricalRetry,
-            historicalUploadLimitsIndex: TPNativeHealth.historicalUploadLimitsIndex,
-            historicalUploadMaxLimitsIndex: TPNativeHealth.historicalUploadMaxLimitsIndex,
-            historicalUploadCurrentDay: TPNativeHealth.historicalUploadCurrentDay,
+            isUploadingHistoricalRetry:
+              TPNativeHealth.isUploadingHistoricalRetry,
+            historicalUploadLimitsIndex:
+              TPNativeHealth.historicalUploadLimitsIndex,
+            historicalUploadMaxLimitsIndex:
+              TPNativeHealth.historicalUploadMaxLimitsIndex,
+            historicalUploadCurrentDay:
+              TPNativeHealth.historicalUploadCurrentDay,
             historicalUploadTotalDays: TPNativeHealth.historicalUploadTotalDays,
-            historicalUploadTotalSamples: TPNativeHealth.historicalUploadTotalSamples,
-            historicalUploadTotalDeletes: TPNativeHealth.historicalUploadTotalDeletes,
-            turnOffHistoricalUploaderReason: TPNativeHealth.turnOffHistoricalUploaderReason,
-            turnOffHistoricalUploaderError: TPNativeHealth.turnOffHistoricalUploaderError,
+            historicalUploadTotalSamples:
+              TPNativeHealth.historicalUploadTotalSamples,
+            historicalUploadTotalDeletes:
+              TPNativeHealth.historicalUploadTotalDeletes,
+            turnOffHistoricalUploaderReason:
+              TPNativeHealth.turnOffHistoricalUploaderReason,
+            turnOffHistoricalUploaderError:
+              TPNativeHealth.turnOffHistoricalUploaderError,
           })
         );
       } else {
-      dispatch(
+        dispatch(
           healthStateSet({
             isUploadingCurrent: TPNativeHealth.isUploadingCurrent,
             isUploadingCurrentRetry: TPNativeHealth.isUploadingCurrentRetry,
             currentUploadLimitsIndex: TPNativeHealth.currentUploadLimitsIndex,
-            currentUploadMaxLimitsIndex: TPNativeHealth.currentUploadMaxLimitsIndex,
+            currentUploadMaxLimitsIndex:
+              TPNativeHealth.currentUploadMaxLimitsIndex,
             currentUploadTotalSamples: TPNativeHealth.currentUploadTotalSamples,
             currentUploadTotalDeletes: TPNativeHealth.currentUploadTotalDeletes,
-            turnOffCurrentUploaderReason: TPNativeHealth.turnOffCurrentUploaderReason,
-            turnOffUploaderCurrentError: TPNativeHealth.turnOffUploaderCurrentError,
+            turnOffCurrentUploaderReason:
+              TPNativeHealth.turnOffCurrentUploaderReason,
+            turnOffUploaderCurrentError:
+              TPNativeHealth.turnOffUploaderCurrentError,
           })
         );
       }
@@ -138,20 +164,26 @@ class AppWithNavigationState extends PureComponent {
       if (uploaderType === "historical") {
         dispatch(
           healthStateSet({
-            isUploadingHistoricalRetry: TPNativeHealth.isUploadingHistoricalRetry,
-            historicalUploadLimitsIndex: TPNativeHealth.historicalUploadLimitsIndex,
-            historicalUploadMaxLimitsIndex: TPNativeHealth.historicalUploadMaxLimitsIndex,
-            retryHistoricalUploadReason: TPNativeHealth.retryHistoricalUploadReason,
-            retryHistoricalUploadError: TPNativeHealth.retryHistoricalUploadError,
+            isUploadingHistoricalRetry:
+              TPNativeHealth.isUploadingHistoricalRetry,
+            historicalUploadLimitsIndex:
+              TPNativeHealth.historicalUploadLimitsIndex,
+            historicalUploadMaxLimitsIndex:
+              TPNativeHealth.historicalUploadMaxLimitsIndex,
+            retryHistoricalUploadReason:
+              TPNativeHealth.retryHistoricalUploadReason,
+            retryHistoricalUploadError:
+              TPNativeHealth.retryHistoricalUploadError,
           })
         );
       } else {
-      dispatch(
+        dispatch(
           healthStateSet({
             isUploadingCurrent: TPNativeHealth.isUploadingCurrent,
             isUploadingCurrentRetry: TPNativeHealth.isUploadingCurrentRetry,
             currentUploadLimitsIndex: TPNativeHealth.currentUploadLimitsIndex,
-            currentUploadMaxLimitsIndex: TPNativeHealth.currentUploadMaxLimitsIndex,
+            currentUploadMaxLimitsIndex:
+              TPNativeHealth.currentUploadMaxLimitsIndex,
             retryCurrentUploadReason: TPNativeHealth.retryCurrentUploadReason,
             retryCurrentUploadError: TPNativeHealth.retryCurrentUploadError,
           })
@@ -166,14 +198,25 @@ class AppWithNavigationState extends PureComponent {
           healthStateSet({
             isUploadingHistorical: TPNativeHealth.isUploadingHistorical,
             isHistoricalUploadPending: TPNativeHealth.isHistoricalUploadPending,
-            historicalUploadLimitsIndex: TPNativeHealth.historicalUploadLimitsIndex,
-            historicalUploadMaxLimitsIndex: TPNativeHealth.historicalUploadMaxLimitsIndex,
-            historicalUploadCurrentDay: TPNativeHealth.historicalUploadCurrentDay,
+            historicalUploadLimitsIndex:
+              TPNativeHealth.historicalUploadLimitsIndex,
+            historicalUploadMaxLimitsIndex:
+              TPNativeHealth.historicalUploadMaxLimitsIndex,
+            historicalUploadCurrentDay:
+              TPNativeHealth.historicalUploadCurrentDay,
             historicalUploadTotalDays: TPNativeHealth.historicalUploadTotalDays,
-            historicalUploadTotalSamples: TPNativeHealth.historicalUploadTotalSamples,
-            historicalUploadTotalDeletes: TPNativeHealth.historicalUploadTotalDeletes,
-            turnOffHistoricalUploaderReason: TPNativeHealth.turnOffHistoricalUploaderReason,
-            turnOffHistoricalUploaderError: TPNativeHealth.turnOffHistoricalUploaderError,
+            historicalUploadTotalSamples:
+              TPNativeHealth.historicalUploadTotalSamples,
+            historicalUploadTotalDeletes:
+              TPNativeHealth.historicalUploadTotalDeletes,
+            historicalUploadEarliestSampleTime:
+              TPNativeHealth.historicalUploadEarliestSampleTime,
+            historicalUploadLatestSampleTime:
+              TPNativeHealth.historicalUploadLatestSampleTime,
+            turnOffHistoricalUploaderReason:
+              TPNativeHealth.turnOffHistoricalUploaderReason,
+            turnOffHistoricalUploaderError:
+              TPNativeHealth.turnOffHistoricalUploaderError,
           })
         );
       } else {
@@ -181,12 +224,21 @@ class AppWithNavigationState extends PureComponent {
           healthStateSet({
             isUploadingCurrent: TPNativeHealth.isUploadingCurrent,
             currentUploadLimitsIndex: TPNativeHealth.currentUploadLimitsIndex,
-            currentUploadMaxLimitsIndex: TPNativeHealth.currentUploadMaxLimitsIndex,
+            currentUploadMaxLimitsIndex:
+              TPNativeHealth.currentUploadMaxLimitsIndex,
             currentUploadTotalSamples: TPNativeHealth.currentUploadTotalSamples,
             currentUploadTotalDeletes: TPNativeHealth.currentUploadTotalDeletes,
-            turnOffCurrentUploaderReason: TPNativeHealth.turnOffCurrentUploaderReason,
-            turnOffCurrentUploaderError: TPNativeHealth.turnOffCurrentUploaderReason,
-            lastCurrentUploadUiDescription: TPNativeHealth.lastCurrentUploadUiDescription,
+            currentUploadEarliestSampleTime:
+              TPNativeHealth.currentUploadEarliestSampleTime,
+            currentUploadLatestSampleTime:
+              TPNativeHealth.currentUploadLatestSampleTime,
+            currentStartAnchorTime: TPNativeHealth.currentStartAnchorTime,
+            turnOffCurrentUploaderReason:
+              TPNativeHealth.turnOffCurrentUploaderReason,
+            turnOffCurrentUploaderError:
+              TPNativeHealth.turnOffCurrentUploaderReason,
+            lastCurrentUploadUiDescription:
+              TPNativeHealth.lastCurrentUploadUiDescription,
           })
         );
       }

--- a/src/models/TPNativeHealth.js
+++ b/src/models/TPNativeHealth.js
@@ -26,6 +26,8 @@ class TPNativeHealthSingletonClass {
     this.historicalUploadTotalDays = 0;
     this.historicalUploadTotalSamples = 0;
     this.historicalUploadTotalDeletes = 0;
+    this.historicalUploadEarliestSampleTime = "";
+    this.historicalUploadLatestSampleTime = "";
     this.turnOffHistoricalUploaderReason = "";
     this.turnOffHistoricalUploaderError = "";
     this.isUploadingHistoricalRetry = false;
@@ -37,6 +39,9 @@ class TPNativeHealthSingletonClass {
     this.isUploadingCurrent = false;
     this.currentUploadTotalSamples = 0;
     this.currentUploadTotalDeletes = 0;
+    this.currentUploadEarliestSampleTime = "";
+    this.currentUploadLatestSampleTime = "";
+    this.currentStartAnchorTime = "";
     this.turnOffCurrentUploaderReason = "";
     this.turnOffCurrentUploaderError = "";
     this.isUploadingCurrentRetry = false;
@@ -52,34 +57,6 @@ class TPNativeHealthSingletonClass {
       this.nativeModule = NativeModules.TPNativeHealth;
 
       this.healthKitInterfaceConfiguration = this.nativeModule.healthKitInterfaceConfiguration();
-      const uploaderProgress = this.nativeModule.uploaderProgress();
-
-      this.isUploadingHistorical = uploaderProgress.isUploadingHistorical;
-      this.isHistoricalUploadPending =
-        uploaderProgress.isHistoricalUploadPending;
-      this.historicalUploadLimitsIndex =
-        uploaderProgress.historicalUploadLimitsIndex;
-      this.historicalUploadMaxLimitsIndex =
-        uploaderProgress.historicalUploadMaxLimitsIndex;
-      this.historicalUploadCurrentDay =
-        uploaderProgress.historicalUploadCurrentDay;
-      this.historicalUploadTotalDays =
-        uploaderProgress.historicalUploadTotalDays;
-      this.historicalUploadTotalSamples =
-        uploaderProgress.historicalUploadTotalSamples;
-      this.historicalUploadTotalDeletes =
-        uploaderProgress.historicalUploadTotalDeletes;
-
-      this.isUploadingCurrent = uploaderProgress.isUploadingCurrent;
-      this.currentUploadLimitsIndex = uploaderProgress.currentUploadLimitsIndex;
-      this.currentUploadMaxLimitsIndex =
-        uploaderProgress.currentUploadMaxLimitsIndex;
-      this.currentUploadTotalSamples =
-        uploaderProgress.currentUploadTotalSamples;
-      this.currentUploadTotalDeletes =
-        uploaderProgress.currentUploadTotalDeletes;
-      this.lastCurrentUploadUiDescription =
-        uploaderProgress.lastCurrentUploadUiDescription;
 
       const events = new NativeEventEmitter(NativeModules.TPNativeHealth);
       events.addListener(
@@ -191,6 +168,14 @@ class TPNativeHealthSingletonClass {
     }
   }
 
+  resetCurrentUploader() {
+    try {
+      this.nativeModule.resetCurrentUploader();
+    } catch (error) {
+      // console.log(`error: ${error}`);
+    }
+  }
+
   onHealthKitInterfaceConfiguration = params => {
     this.healthKitInterfaceConfiguration = { ...params };
     this.notify("onHealthKitInterfaceConfiguration");
@@ -294,6 +279,10 @@ class TPNativeHealthSingletonClass {
       this.updateHistoricalUploadCurrentDayIfComplete();
       this.historicalUploadTotalSamples = params.historicalUploadTotalSamples;
       this.historicalUploadTotalDeletes = params.historicalUploadTotalDeletes;
+      this.historicalUploadEarliestSampleTime =
+        params.historicalUploadEarliestSampleTime;
+      this.historicalUploadLatestSampleTime =
+        params.historicalUploadLatestSampleTime;
       this.historicalUploadLimitsIndex = params.historicalUploadLimitsIndex;
       this.historicalUploadMaxLimitsIndex =
         params.historicalUploadMaxLimitsIndex;
@@ -301,6 +290,10 @@ class TPNativeHealthSingletonClass {
       this.isUploadingCurrent = params.isUploadingCurrent;
       this.currentUploadTotalSamples = params.currentUploadTotalSamples;
       this.currentUploadTotalDeletes = params.currentUploadTotalDeletes;
+      this.currentUploadEarliestSampleTime =
+        params.currentUploadEarliestSampleTime;
+      this.currentUploadLatestSampleTime = params.currentUploadLatestSampleTime;
+      this.currentStartAnchorTime = params.currentStartAnchorTime;
       this.currentUploadLimitsIndex = params.currentUploadLimitsIndex;
       this.currentUploadMaxLimitsIndex = params.currentUploadMaxLimitsIndex;
       this.lastCurrentUploadUiDescription =
@@ -327,6 +320,10 @@ class TPNativeHealthSingletonClass {
         uploaderProgress.historicalUploadTotalSamples;
       this.historicalUploadTotalDeletes =
         uploaderProgress.historicalUploadTotalDeletes;
+      this.historicalUploadEarliestSampleTime =
+        uploaderProgress.historicalUploadEarliestSampleTime;
+      this.historicalUploadLatestSampleTime =
+        uploaderProgress.historicalUploadLatestSampleTime;
 
       this.isUploadingCurrent = uploaderProgress.isUploadingCurrent;
       this.currentUploadLimitsIndex = uploaderProgress.currentUploadLimitsIndex;
@@ -336,6 +333,11 @@ class TPNativeHealthSingletonClass {
         uploaderProgress.currentUploadTotalSamples;
       this.currentUploadTotalDeletes =
         uploaderProgress.currentUploadTotalDeletes;
+      this.currentUploadEarliestSampleTime =
+        uploaderProgress.currentUploadEarliestSampleTime;
+      this.currentUploadLatestSampleTime =
+        uploaderProgress.currentUploadLatestSampleTime;
+      this.currentStartAnchorTime = uploaderProgress.currentStartAnchorTime;
       this.lastCurrentUploadUiDescription =
         uploaderProgress.lastCurrentUploadUiDescription;
 

--- a/src/screens/DebugHealthScreen.js
+++ b/src/screens/DebugHealthScreen.js
@@ -33,6 +33,7 @@ import PrimaryTheme from "../themes/PrimaryTheme";
 import Colors from "../constants/Colors";
 import getTheme from "../../native-base-theme/components";
 import commonColor from "../../native-base-theme/variables/commonColor";
+import { formatDateForNoteList } from "../utils/formatDate";
 
 const styles = StyleSheet.create({
   uploadButton: { marginRight: 0, paddingLeft: 0 },
@@ -106,27 +107,50 @@ class DebugHealthScreen extends PureComponent {
 
   onUploaderSuppressDeletesValueChange = value => {
     TPNativeHealth.setUploaderSuppressDeletes(value);
-  }
+  };
 
   onUploaderSimulateValueChange = value => {
     TPNativeHealth.setUploaderSimulate(value);
-  }
+  };
 
   onUploaderIncludeSensitiveInfoValueChange = value => {
     TPNativeHealth.setUploaderIncludeSensitiveInfo(value);
-  }
+  };
 
   onUploaderIncludeCFNetworkDiagnosticsValueChange = value => {
-    Alert.alert("Relaunch Required", "Changing CFNetwork Diagnostics requires a relaunch of the app.", [
-      {
-        text: "OK",
-      },
-    ]);
+    Alert.alert(
+      "Relaunch Required",
+      "Changing CFNetwork Diagnostics requires a relaunch of the app.",
+      [
+        {
+          text: "OK",
+        },
+      ]
+    );
     this.setState({
       restartRequiredForCFNetworkDiagnosticChange: true,
     });
     TPNativeHealth.setUploaderIncludeCFNetworkDiagnostics(value);
-  }
+  };
+
+  onPressResetButton = () => {
+    Alert.alert(
+      "Reset Current?",
+      "Reset persistent state of Current uploader so it will start fresh from 4 hours in the past",
+      [
+        {
+          text: "Cancel",
+          style: "cancel",
+        },
+        {
+          text: "OK",
+          onPress: () => {
+            TPNativeHealth.resetCurrentUploader();
+          },
+        },
+      ]
+    );
+  };
 
   onPressUploadButton = () => {
     TPNativeHealth.startUploadingHistorical();
@@ -134,10 +158,7 @@ class DebugHealthScreen extends PureComponent {
 
   onPressCancelButton = () => {
     const {
-      health: {
-        isUploadingHistorical,
-        isHistoricalUploadPending,
-      },
+      health: { isUploadingHistorical, isHistoricalUploadPending },
     } = this.props;
 
     if (isUploadingHistorical || isHistoricalUploadPending) {
@@ -158,33 +179,34 @@ class DebugHealthScreen extends PureComponent {
 
   onPressCancelButton = () => {
     const {
-      health: {
-        isUploadingHistorical,
-        isHistoricalUploadPending,
-      },
+      health: { isUploadingHistorical, isHistoricalUploadPending },
     } = this.props;
 
     if (isUploadingHistorical || isHistoricalUploadPending) {
-      Alert.alert("Stop Syncing?", "Stop syncing and reset historical uploader for fresh upload", [
-        {
-          text: "Cancel",
-          style: "cancel",
-        },
-        {
-          text: "OK",
-          onPress: () => {
-            TPNativeHealth.stopUploadingHistoricalAndReset();
+      Alert.alert(
+        "Stop Syncing?",
+        "Stop syncing and reset historical uploader for fresh upload",
+        [
+          {
+            text: "Cancel",
+            style: "cancel",
           },
-        },
-      ]);
+          {
+            text: "OK",
+            onPress: () => {
+              TPNativeHealth.stopUploadingHistoricalAndReset();
+            },
+          },
+        ]
+      );
     }
   };
 
   onClose = () => {
     const { navigateDebugSettings, navigateGoBack } = this.props;
-    navigateGoBack()
-    navigateDebugSettings()
-  }
+    navigateGoBack();
+    navigateDebugSettings();
+  };
 
   timeChanged = () => {
     TPNativeHealth.refreshUploadStats();
@@ -380,19 +402,27 @@ class DebugHealthScreen extends PureComponent {
 
   renderUploaderOptions() {
     const {
-      health: { uploaderSuppressDeletes, uploaderSimulate, includeSensitiveInfo, includeCFNetworkDiagnostics },
+      health: {
+        uploaderSuppressDeletes,
+        uploaderSimulate,
+        includeSensitiveInfo,
+        includeCFNetworkDiagnostics,
+      },
     } = this.props;
 
     return (
       <>
-        <Grid style={{paddingTop: 8}}>
+        <Grid style={{ paddingTop: 8 }}>
           <Row>
             <Left styles={styles.left}>
               <Text>Suppress deletes</Text>
             </Left>
             <Right style={styles.right}>
               <Switch
-                style={{transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }], marginRight: -6}}
+                style={{
+                  transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }],
+                  marginRight: -6,
+                }}
                 trackColor={{ true: Colors.brightBlue, false: null }}
                 onValueChange={this.onUploaderSuppressDeletesValueChange}
                 value={uploaderSuppressDeletes}
@@ -407,7 +437,10 @@ class DebugHealthScreen extends PureComponent {
             </Left>
             <Right style={styles.right}>
               <Switch
-                style={{transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }], marginRight: -6}}
+                style={{
+                  transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }],
+                  marginRight: -6,
+                }}
                 trackColor={{ true: Colors.brightBlue, false: null }}
                 onValueChange={this.onUploaderSimulateValueChange}
                 value={uploaderSimulate}
@@ -422,7 +455,10 @@ class DebugHealthScreen extends PureComponent {
             </Left>
             <Right style={styles.right}>
               <Switch
-                style={{transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }], marginRight: -6}}
+                style={{
+                  transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }],
+                  marginRight: -6,
+                }}
                 trackColor={{ true: Colors.brightBlue, false: null }}
                 onValueChange={this.onUploaderIncludeSensitiveInfoValueChange}
                 value={includeSensitiveInfo}
@@ -433,20 +469,31 @@ class DebugHealthScreen extends PureComponent {
         <Grid>
           <Row>
             <Left styles={styles.left}>
-              <Text>{`Include CFNetwork diagnostics${this.state.restartRequiredForCFNetworkDiagnosticChange ? " (restart required)" : ""}`}</Text>
+              <Text>
+                {`Include CFNetwork diagnostics${
+                  this.state.restartRequiredForCFNetworkDiagnosticChange
+                    ? " (restart required)"
+                    : ""
+                }`}
+              </Text>
             </Left>
             <Right style={styles.right}>
               <Switch
-                style={{transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }], marginRight: -6}}
+                style={{
+                  transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }],
+                  marginRight: -6,
+                }}
                 trackColor={{ true: Colors.brightBlue, false: null }}
-                onValueChange={this.onUploaderIncludeCFNetworkDiagnosticsValueChange}
+                onValueChange={
+                  this.onUploaderIncludeCFNetworkDiagnosticsValueChange
+                }
                 value={includeCFNetworkDiagnostics}
               />
             </Right>
           </Row>
         </Grid>
       </>
-    )
+    );
   }
 
   renderUploaderTimeoutsist() {
@@ -461,8 +508,8 @@ class DebugHealthScreen extends PureComponent {
         </ListItem>
         <ListItem
           onPress={() => {
-              TPNativeHealth.setUploaderTimeoutsIndex(0)
-            }}
+            TPNativeHealth.setUploaderTimeoutsIndex(0);
+          }}
         >
           <Left style={styles.left}>
             <Grid>
@@ -471,19 +518,14 @@ class DebugHealthScreen extends PureComponent {
               </Row>
             </Grid>
           </Left>
-          <Right
-            style={styles.right}
-          >
-            <Radio
-              selected={uploaderTimeoutsIndex === 0}
-              disabled
-            />
+          <Right style={styles.right}>
+            <Radio selected={uploaderTimeoutsIndex === 0} disabled />
           </Right>
         </ListItem>
         <ListItem
           onPress={() => {
-              TPNativeHealth.setUploaderTimeoutsIndex(1)
-            }}
+            TPNativeHealth.setUploaderTimeoutsIndex(1);
+          }}
         >
           <Left style={styles.left}>
             <Grid>
@@ -498,8 +540,8 @@ class DebugHealthScreen extends PureComponent {
         </ListItem>
         <ListItem
           onPress={() => {
-              TPNativeHealth.setUploaderTimeoutsIndex(2)
-            }}
+            TPNativeHealth.setUploaderTimeoutsIndex(2);
+          }}
         >
           <Left style={styles.left}>
             <Grid>
@@ -528,8 +570,8 @@ class DebugHealthScreen extends PureComponent {
         </ListItem>
         <ListItem
           onPress={() => {
-        TPNativeHealth.setUploaderLimitsIndex(0)
-      }}
+            TPNativeHealth.setUploaderLimitsIndex(0);
+          }}
         >
           <Left style={styles.left}>
             <Grid>
@@ -541,19 +583,14 @@ class DebugHealthScreen extends PureComponent {
               </Row>
             </Grid>
           </Left>
-          <Right
-            style={styles.right}
-          >
-            <Radio
-              selected={uploaderLimitsIndex === 0}
-              disabled
-            />
+          <Right style={styles.right}>
+            <Radio selected={uploaderLimitsIndex === 0} disabled />
           </Right>
         </ListItem>
         <ListItem
           onPress={() => {
-        TPNativeHealth.setUploaderLimitsIndex(1)
-      }}
+            TPNativeHealth.setUploaderLimitsIndex(1);
+          }}
         >
           <Grid>
             <Row>
@@ -575,8 +612,8 @@ class DebugHealthScreen extends PureComponent {
         </ListItem>
         <ListItem
           onPress={() => {
-        TPNativeHealth.setUploaderLimitsIndex(2)
-      }}
+            TPNativeHealth.setUploaderLimitsIndex(2);
+          }}
         >
           <Grid>
             <Row>
@@ -597,7 +634,7 @@ class DebugHealthScreen extends PureComponent {
           </Grid>
         </ListItem>
       </List>
-    )
+    );
   }
 
   renderUploaderSettingsCardItem() {
@@ -632,10 +669,16 @@ class DebugHealthScreen extends PureComponent {
         historicalUploadTotalDays,
         historicalUploadTotalSamples,
         historicalUploadTotalDeletes,
+        historicalUploadEarliestSampleTime, // TODO: my - 0 - use this
+        historicalUploadLatestSampleTime,
       },
     } = this.props;
 
-    if (isUploadingHistorical || (turnOffHistoricalUploaderReason && turnOffHistoricalUploaderReason !== "turned off")) {
+    if (
+      isUploadingHistorical ||
+      (turnOffHistoricalUploaderReason &&
+        turnOffHistoricalUploaderReason !== "turned off")
+    ) {
       let totalDaysStatsText = "";
       if (historicalUploadTotalDays > 0) {
         totalDaysStatsText = `Uploaded ${historicalUploadCurrentDay} of ${historicalUploadTotalDays} days`;
@@ -643,24 +686,35 @@ class DebugHealthScreen extends PureComponent {
       const totalCountsStatsText = `Uploaded ${historicalUploadTotalSamples} samples, ${historicalUploadTotalDeletes} deletes`;
       return (
         <Grid>
-          {
-            totalCountsStatsText ? (
+          {totalCountsStatsText ? (
+            <Row>
+              <Text style={styles.statsText}>{totalCountsStatsText}</Text>
+            </Row>
+          ) : null}
+          {totalDaysStatsText ? (
+            <Row>
+              <Text style={styles.statsText}>{totalDaysStatsText}</Text>
+            </Row>
+          ) : null}
+          {historicalUploadEarliestSampleTime &&
+          historicalUploadLatestSampleTime ? (
+            <>
               <Row>
                 <Text style={styles.statsText}>
-                  {totalCountsStatsText}
+                  {`earliest sample: ${formatDateForNoteList(
+                    historicalUploadEarliestSampleTime
+                  )}`}
                 </Text>
               </Row>
-            ) : null
-          }
-          {
-            totalDaysStatsText ? (
               <Row>
                 <Text style={styles.statsText}>
-                  {totalDaysStatsText}
+                  {`latest sample: ${formatDateForNoteList(
+                    historicalUploadLatestSampleTime
+                  )}`}
                 </Text>
               </Row>
-            ) : null
-          }
+            </>
+          ) : null}
         </Grid>
       );
     }
@@ -686,15 +740,15 @@ class DebugHealthScreen extends PureComponent {
       },
     } = this.props;
 
-    let uploadStatusText = "Not uploading"
+    let uploadStatusText = "Not uploading";
     if (isUploadingHistoricalRetry) {
-      uploadStatusText = `Retrying due to: ${retryHistoricalUploadError}`
+      uploadStatusText = `Retrying due to: ${retryHistoricalUploadError}`;
     } else if (isUploadingHistorical) {
-      uploadStatusText = "Uploading..."
+      uploadStatusText = "Uploading...";
     } else if (isHistoricalUploadPending) {
-      uploadStatusText = "Upload pending..."
+      uploadStatusText = "Upload pending...";
     } else if (isTurningInterfaceOn) {
-      uploadStatusText = "Preparing"
+      uploadStatusText = "Preparing";
     }
 
     return (
@@ -704,66 +758,57 @@ class DebugHealthScreen extends PureComponent {
             <Text style={styles.statsText}>{uploadStatusText}</Text>
           </Left>
         </Row>
-        {
-          !isUploadingHistorical ?
-          (
+        {!isUploadingHistorical ? (
+          <Row>
+            <Left style={styles.left}>
+              <Text style={styles.statsText}>Stopped reason:</Text>
+            </Left>
+            <Right style={styles.right}>
+              <Text style={styles.statsText}>
+                {turnOffHistoricalUploaderReason}
+              </Text>
+            </Right>
+          </Row>
+        ) : null}
+        {turnOffHistoricalUploaderError &&
+        turnOffHistoricalUploaderReason !== "turned off" ? (
+          <>
             <Row>
-              <Left style={styles.left}>
-                <Text style={styles.statsText}>Stopped reason:</Text>
-              </Left>
-              <Right style={styles.right}>
-                <Text style={styles.statsText}>{turnOffHistoricalUploaderReason}</Text>
-              </Right>
+              <Text style={styles.statsText}>Stopped error:</Text>
             </Row>
-          ) : null
-        }
-        {
-          turnOffHistoricalUploaderError && turnOffHistoricalUploaderReason !== "turned off" ?
-          (
+            <Row>
+              <Text style={styles.statsText}>
+                {turnOffHistoricalUploaderError}
+              </Text>
+            </Row>
+          </>
+        ) : null}
+        {isUploadingHistorical ||
+        (turnOffHistoricalUploaderReason &&
+          turnOffHistoricalUploaderReason !== "turned off") ? (
             <>
               <Row>
-                <Text style={styles.statsText}>Stopped error:</Text>
-              </Row>
-              <Row>
-                <Text style={styles.statsText}>{turnOffHistoricalUploaderError}</Text>
-              </Row>
-            </>
-          ) : null
-        }
-        {
-          isUploadingHistorical || (turnOffHistoricalUploaderReason && turnOffHistoricalUploaderReason !== "turned off") ?
-          (
-            <>
-              <Row>
-                <Text style={styles.statsText}>{`Limits index: ${historicalUploadLimitsIndex}, maxIndex: ${historicalUploadMaxLimitsIndex}`}</Text>
+                <Text style={styles.statsText}>
+                  {`Limits index: ${historicalUploadLimitsIndex}, maxIndex: ${historicalUploadMaxLimitsIndex}`}
+                </Text>
               </Row>
             </>
-          ) : null
-        }
-        {
-            uploaderSuppressDeletes ?
-            (
-              <Row>
-                <Text style={styles.statsText}>Suppress deletes</Text>
-              </Row>
-            ) : null
-        }
-        {
-          uploaderSimulate ?
-          (
-            <Row>
-              <Text style={styles.statsText}>Simulate upload</Text>
-            </Row>
-          ) : null
-        }
-        {
-          includeSensitiveInfo ?
-          (
-            <Row>
-              <Text style={styles.statsText}>Include sensitive info in logs</Text>
-            </Row>
-          ) : null
-        }
+        ) : null}
+        {uploaderSuppressDeletes ? (
+          <Row>
+            <Text style={styles.statsText}>Suppress deletes</Text>
+          </Row>
+        ) : null}
+        {uploaderSimulate ? (
+          <Row>
+            <Text style={styles.statsText}>Simulate upload</Text>
+          </Row>
+        ) : null}
+        {includeSensitiveInfo ? (
+          <Row>
+            <Text style={styles.statsText}>Include sensitive info in logs</Text>
+          </Row>
+        ) : null}
       </Grid>
     );
   }
@@ -790,7 +835,11 @@ class DebugHealthScreen extends PureComponent {
               <Row>
                 <Button
                   transparent
-                  disabled={isUploadingHistorical || isHistoricalUploadPending || (!isInterfaceOn && !isTurningInterfaceOn)}
+                  disabled={
+                    isUploadingHistorical ||
+                    isHistoricalUploadPending ||
+                    (!isInterfaceOn && !isTurningInterfaceOn)
+                  }
                   onPress={this.onPressUploadButton}
                 >
                   <Text>Start upload</Text>
@@ -798,7 +847,9 @@ class DebugHealthScreen extends PureComponent {
                 <Button
                   transparent
                   onPress={this.onPressCancelButton}
-                  disabled={!isUploadingHistorical && !isHistoricalUploadPending}
+                  disabled={
+                    !isUploadingHistorical && !isHistoricalUploadPending
+                  }
                 >
                   <Text>Cancel</Text>
                 </Button>
@@ -835,13 +886,13 @@ class DebugHealthScreen extends PureComponent {
       },
     } = this.props;
 
-    let uploadStatusText = "Current uploader not on"
+    let uploadStatusText = "Current uploader not on";
     if (isUploadingCurrentRetry) {
-      uploadStatusText = `Retrying due to: ${retryCurrentUploadError}`
+      uploadStatusText = `Retrying due to: ${retryCurrentUploadError}`;
     } else if (isUploadingCurrent) {
-      uploadStatusText = "Current uploader is on"
+      uploadStatusText = "Current uploader is on";
     } else if (isTurningInterfaceOn) {
-      uploadStatusText = "Preparing"
+      uploadStatusText = "Preparing";
     }
 
     return (
@@ -851,66 +902,57 @@ class DebugHealthScreen extends PureComponent {
             <Text style={styles.statsText}>{uploadStatusText}</Text>
           </Left>
         </Row>
-        {
-          !isUploadingCurrent ?
-          (
+        {!isUploadingCurrent ? (
+          <Row>
+            <Left style={styles.left}>
+              <Text style={styles.statsText}>Stopped reason:</Text>
+            </Left>
+            <Right style={styles.right}>
+              <Text style={styles.statsText}>
+                {turnOffCurrentUploaderReason}
+              </Text>
+            </Right>
+          </Row>
+        ) : null}
+        {turnOffCurrentUploaderError &&
+        turnOffCurrentUploaderReason !== "turned off" ? (
+          <>
             <Row>
-              <Left style={styles.left}>
-                <Text style={styles.statsText}>Stopped reason:</Text>
-              </Left>
-              <Right style={styles.right}>
-                <Text style={styles.statsText}>{turnOffCurrentUploaderReason}</Text>
-              </Right>
+              <Text style={styles.statsText}>Stopped error:</Text>
             </Row>
-          ) : null
-        }
-        {
-          turnOffCurrentUploaderError && turnOffCurrentUploaderReason !== "turned off" ?
-          (
+            <Row>
+              <Text style={styles.statsText}>
+                {turnOffCurrentUploaderError}
+              </Text>
+            </Row>
+          </>
+        ) : null}
+        {isUploadingCurrent ||
+        (turnOffCurrentUploaderError &&
+          turnOffCurrentUploaderReason !== "turned off") ? (
             <>
               <Row>
-                <Text style={styles.statsText}>Stopped error:</Text>
-              </Row>
-              <Row>
-                <Text style={styles.statsText}>{turnOffCurrentUploaderError}</Text>
-              </Row>
-            </>
-          ) : null
-        }
-        {
-          isUploadingCurrent || (turnOffCurrentUploaderError && turnOffCurrentUploaderReason !== "turned off") ?
-          (
-            <>
-              <Row>
-                <Text style={styles.statsText}>{`Limits index: ${currentUploadLimitsIndex}, maxIndex: ${currentUploadMaxLimitsIndex}`}</Text>
+                <Text style={styles.statsText}>
+                  {`Limits index: ${currentUploadLimitsIndex}, maxIndex: ${currentUploadMaxLimitsIndex}`}
+                </Text>
               </Row>
             </>
-          ) : null
-        }
-        {
-            uploaderSuppressDeletes ?
-            (
-              <Row>
-                <Text style={styles.statsText}>Suppress deletes</Text>
-              </Row>
-            ) : null
-        }
-        {
-          uploaderSimulate ?
-          (
-            <Row>
-              <Text style={styles.statsText}>Simulate upload</Text>
-            </Row>
-          ) : null
-        }
-        {
-          includeSensitiveInfo ?
-          (
-            <Row>
-              <Text style={styles.statsText}>Include sensitive info in logs</Text>
-            </Row>
-          ) : null
-        }
+        ) : null}
+        {uploaderSuppressDeletes ? (
+          <Row>
+            <Text style={styles.statsText}>Suppress deletes</Text>
+          </Row>
+        ) : null}
+        {uploaderSimulate ? (
+          <Row>
+            <Text style={styles.statsText}>Simulate upload</Text>
+          </Row>
+        ) : null}
+        {includeSensitiveInfo ? (
+          <Row>
+            <Text style={styles.statsText}>Include sensitive info in logs</Text>
+          </Row>
+        ) : null}
       </Grid>
     );
   }
@@ -922,23 +964,53 @@ class DebugHealthScreen extends PureComponent {
         isUploadingCurrent,
         currentUploadTotalSamples,
         currentUploadTotalDeletes,
+        currentUploadEarliestSampleTime,
+        currentUploadLatestSampleTime,
+        currentStartAnchorTime,
         lastCurrentUploadUiDescription,
       },
     } = this.props;
 
-    if (isUploadingCurrent || (turnOffCurrentUploaderReason && turnOffCurrentUploaderReason !== "turned off")) {
+    if (
+      isUploadingCurrent ||
+      (turnOffCurrentUploaderReason &&
+        turnOffCurrentUploaderReason !== "turned off")
+    ) {
       const totalCountsStatsText = `Uploaded ${currentUploadTotalSamples} samples, ${currentUploadTotalDeletes} deletes`;
       return (
         <Grid>
-          {
-            totalCountsStatsText ? (
+          {totalCountsStatsText ? (
+            <Row>
+              <Text style={styles.statsText}>{totalCountsStatsText}</Text>
+            </Row>
+          ) : null}
+          {currentStartAnchorTime ? (
+            <Row>
+              <Text style={styles.statsText}>
+                {`start anchor: ${formatDateForNoteList(
+                  currentStartAnchorTime
+                )}`}
+              </Text>
+            </Row>
+          ) : null}
+          {currentUploadEarliestSampleTime && currentUploadLatestSampleTime ? (
+            <>
               <Row>
                 <Text style={styles.statsText}>
-                  {totalCountsStatsText}
+                  {`earliest sample: ${formatDateForNoteList(
+                    currentUploadEarliestSampleTime
+                  )}`}
                 </Text>
               </Row>
-            ) : null
-          }
+              <Row>
+                <Text style={styles.statsText}>
+                  {`latest sample: ${formatDateForNoteList(
+                    currentUploadLatestSampleTime
+                  )}`}
+                </Text>
+              </Row>
+            </>
+          ) : null}
           <Row>
             <Text style={styles.statsText}>
               {lastCurrentUploadUiDescription}
@@ -953,9 +1025,7 @@ class DebugHealthScreen extends PureComponent {
 
   renderCurrentHealthCard() {
     const {
-      health: {
-        shouldShowHealthKitUI,
-      },
+      health: { shouldShowHealthKitUI },
     } = this.props;
 
     if (shouldShowHealthKitUI) {
@@ -965,6 +1035,11 @@ class DebugHealthScreen extends PureComponent {
             <Grid>
               <Row>
                 <Text style={styles.headerStyle}>Current</Text>
+              </Row>
+              <Row>
+                <Button transparent onPress={this.onPressResetButton}>
+                  <Text>Reset</Text>
+                </Button>
               </Row>
             </Grid>
           </CardItem>

--- a/src/screens/DebugHealthScreen.js
+++ b/src/screens/DebugHealthScreen.js
@@ -734,7 +734,6 @@ class DebugHealthScreen extends PureComponent {
         retryHistoricalUploadError,
         historicalUploadLimitsIndex,
         historicalUploadMaxLimitsIndex,
-        uploaderSuppressDeletes,
         uploaderSimulate,
         includeSensitiveInfo,
       },
@@ -758,7 +757,7 @@ class DebugHealthScreen extends PureComponent {
             <Text style={styles.statsText}>{uploadStatusText}</Text>
           </Left>
         </Row>
-        {!isUploadingHistorical ? (
+        {!isUploadingHistorical && turnOffHistoricalUploaderReason ? (
           <Row>
             <Left style={styles.left}>
               <Text style={styles.statsText}>Stopped reason:</Text>
@@ -794,17 +793,19 @@ class DebugHealthScreen extends PureComponent {
               </Row>
             </>
         ) : null}
-        {uploaderSuppressDeletes ? (
+        {isUploadingHistorical ? (
           <Row>
-            <Text style={styles.statsText}>Suppress deletes</Text>
+            <Text style={styles.statsText}>
+              Historical always suppresses deletes
+            </Text>
           </Row>
         ) : null}
-        {uploaderSimulate ? (
+        {isUploadingHistorical && uploaderSimulate ? (
           <Row>
             <Text style={styles.statsText}>Simulate upload</Text>
           </Row>
         ) : null}
-        {includeSensitiveInfo ? (
+        {isUploadingHistorical && includeSensitiveInfo ? (
           <Row>
             <Text style={styles.statsText}>Include sensitive info in logs</Text>
           </Row>
@@ -902,7 +903,7 @@ class DebugHealthScreen extends PureComponent {
             <Text style={styles.statsText}>{uploadStatusText}</Text>
           </Left>
         </Row>
-        {!isUploadingCurrent ? (
+        {!isUploadingCurrent && turnOffCurrentUploaderReason ? (
           <Row>
             <Left style={styles.left}>
               <Text style={styles.statsText}>Stopped reason:</Text>
@@ -938,17 +939,17 @@ class DebugHealthScreen extends PureComponent {
               </Row>
             </>
         ) : null}
-        {uploaderSuppressDeletes ? (
+        {isUploadingCurrent && uploaderSuppressDeletes ? (
           <Row>
             <Text style={styles.statsText}>Suppress deletes</Text>
           </Row>
         ) : null}
-        {uploaderSimulate ? (
+        {isUploadingCurrent && uploaderSimulate ? (
           <Row>
             <Text style={styles.statsText}>Simulate upload</Text>
           </Row>
         ) : null}
-        {includeSensitiveInfo ? (
+        {isUploadingCurrent && includeSensitiveInfo ? (
           <Row>
             <Text style={styles.statsText}>Include sensitive info in logs</Text>
           </Row>


### PR DESCRIPTION
Fix MOBILE-185, MOBILE-182, MOBILE-177

Also updates to 1.0.5 HealthKit uploader to pick up:
- Add support for persistent earliest/latest sample times for current phase uploader, and expose in uploader progress
- Expose currentStartDate anchor in uploader progress
- Use DispatchQueue.main.async for a few uploader calls that were being called on main thread and needed to interact with UIApplication applicationState (to check if in background)
- Make sure to reset isRetry in uploader if we successfully retried
- Add logging for metadata for deleted samples
- Bump uploader version (to force reset of persistent state)
- Add support for persistent earliest/latest sample times for historical phase uploader, and expose in uploader progress