### PR TITLE
MOBILE-187

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -63,11 +63,12 @@ target 'Tidepool' do
   pod 'RollbarReactNative', :path => '../node_modules/rollbar-react-native'
   pod 'RNDeviceInfo', :path => '../node_modules/react-native-device-info'
 
-  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '1.0.6'
+  pod 'TPHealthKitUploader', :git => 'https://github.com/tidepool-org/healthkit-uploader', :tag => '1.0.7'
   pod 'SwiftyJSON', '5.0.0'
   pod 'CocoaLumberjack/Swift', '3.5.3'
   pod 'Alamofire', '4.9.1'
   pod 'Zip', '1.1.0'
+  pod 'CSV.swift', '2.4.3'
 
   post_install do |installer|
     installer.pods_project.main_group.tab_width = '2';

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,6 +9,7 @@ PODS:
     - CocoaLumberjack/Core
   - Crashlytics (3.13.4):
     - Fabric (~> 1.10.2)
+  - CSV.swift (2.4.3)
   - DoubleConversion (1.1.6)
   - EXAppLoaderProvider (8.0.0)
   - EXConstants (8.0.0):
@@ -331,6 +332,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (= 4.9.1)
   - CocoaLumberjack/Swift (= 3.5.3)
+  - CSV.swift (= 2.4.3)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXAppLoaderProvider (from `../node_modules/expo-app-loader-provider/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
@@ -375,7 +377,7 @@ DEPENDENCIES:
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RollbarReactNative (from `../node_modules/rollbar-react-native`)
   - SwiftyJSON (= 5.0.0)
-  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `1.0.6`)
+  - TPHealthKitUploader (from `https://github.com/tidepool-org/healthkit-uploader`, tag `1.0.7`)
   - UMBarCodeScannerInterface (from `../node_modules/unimodules-barcode-scanner-interface/ios`)
   - UMCameraInterface (from `../node_modules/unimodules-camera-interface/ios`)
   - UMConstantsInterface (from `../node_modules/unimodules-constants-interface/ios`)
@@ -405,6 +407,7 @@ SPEC REPOS:
     - Rollbar
   trunk:
     - Alamofire
+    - CSV.swift
     - SwiftyJSON
     - Zip
 
@@ -505,7 +508,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/rollbar-react-native"
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 1.0.6
+    :tag: 1.0.7
   UMBarCodeScannerInterface:
     :path: !ruby/object:Pathname
     path: "../node_modules/unimodules-barcode-scanner-interface/ios"
@@ -551,7 +554,7 @@ CHECKOUT OPTIONS:
     :tag: ios/2.14.2
   TPHealthKitUploader:
     :git: https://github.com/tidepool-org/healthkit-uploader
-    :tag: 1.0.6
+    :tag: 1.0.7
 
 SPEC CHECKSUMS:
   Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
@@ -559,6 +562,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   Crashlytics: 2dfd686bcb918dc10ee0e76f7f853fe42c7bd552
+  CSV.swift: d38741b349c067b4a6db42237cb0e2974d21ccac
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   EXAppLoaderProvider: ebdb6bc2632c1ccadbe49f5e4104d8d690969c49
   EXConstants: 4051b16c17ef3defa03c541d42811dc92b249146
@@ -622,6 +626,6 @@ SPEC CHECKSUMS:
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
   Zip: 8877eede3dda76bcac281225c20e71c25270774c
 
-PODFILE CHECKSUM: 1d0616389b0603651d65f18bcf7facac8b866e2a
+PODFILE CHECKSUM: e4603c49b3e1b6b53c295ae979da76511854da57
 
 COCOAPODS: 1.8.4

--- a/ios/Tidepool.xcodeproj/project.pbxproj
+++ b/ios/Tidepool.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		4D466CB02348FFC30026406B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D466CAF2348FFC30026406B /* main.swift */; };
 		4D8027D321E417D2003C8B10 /* LaunchScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D8027D221E417D2003C8B10 /* LaunchScreen.m */; };
 		4D8027D621E41806003C8B10 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4D8027D421E41806003C8B10 /* LaunchScreen.storyboard */; };
+		4D9E27EC243659140043EDF7 /* TPDataLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9E27EB243659130043EDF7 /* TPDataLogger.swift */; };
 		4DB2757F2367E62E00AE891B /* TPNativeHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB2757D2367E62D00AE891B /* TPNativeHealth.swift */; };
 		4DB275802367E62E00AE891B /* TPNativeHealthBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DB2757E2367E62E00AE891B /* TPNativeHealthBridge.m */; };
 		4DFFF0712314B8F70007E093 /* TPUploaderAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DFFF0702314B8F70007E093 /* TPUploaderAPI.swift */; };
@@ -46,6 +47,7 @@
 		4D8027D121E417D2003C8B10 /* LaunchScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LaunchScreen.h; sourceTree = "<group>"; };
 		4D8027D221E417D2003C8B10 /* LaunchScreen.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LaunchScreen.m; sourceTree = "<group>"; };
 		4D8027D521E41806003C8B10 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		4D9E27EB243659130043EDF7 /* TPDataLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPDataLogger.swift; sourceTree = "<group>"; };
 		4DB2757D2367E62D00AE891B /* TPNativeHealth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPNativeHealth.swift; sourceTree = "<group>"; };
 		4DB2757E2367E62E00AE891B /* TPNativeHealthBridge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPNativeHealthBridge.m; sourceTree = "<group>"; };
 		4DFFF0702314B8F70007E093 /* TPUploaderAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPUploaderAPI.swift; sourceTree = "<group>"; };
@@ -118,16 +120,17 @@
 			isa = PBXGroup;
 			children = (
 				4D466CAF2348FFC30026406B /* main.swift */,
-				4D466CAD2348FE840026406B /* LogFormatter.swift */,
-				4DFFF07A231D6C640007E093 /* TPAppDelegate.swift */,
 				4DFFF0742314BB110007E093 /* TPApi.swift */,
+				4DFFF07A231D6C640007E093 /* TPAppDelegate.swift */,
 				4DFFF0722314B9950007E093 /* TPDataController.swift */,
-				4D0DF5F923247D41004F6ED6 /* TPSettings.swift */,
-				4DFFF0702314B8F70007E093 /* TPUploaderAPI.swift */,
+				4D9E27EB243659130043EDF7 /* TPDataLogger.swift */,
 				4D08D68323133B0F00CBB2F7 /* TPNative.swift */,
 				4D08D68823134E8800CBB2F7 /* TPNativeBridge.m */,
 				4DB2757D2367E62D00AE891B /* TPNativeHealth.swift */,
 				4DB2757E2367E62E00AE891B /* TPNativeHealthBridge.m */,
+				4D0DF5F923247D41004F6ED6 /* TPSettings.swift */,
+				4DFFF0702314B8F70007E093 /* TPUploaderAPI.swift */,
+				4D466CAD2348FE840026406B /* LogFormatter.swift */,
 				B56386501DB9693800A0598C /* Assets.xcassets */,
 				4D0DF5FD2328BB8E004F6ED6 /* Tidepool.entitlements */,
 				4D08D68023133AB200CBB2F7 /* Tidepool-Bridging-Header.h */,
@@ -338,6 +341,7 @@
 				4DB2757F2367E62E00AE891B /* TPNativeHealth.swift in Sources */,
 				4D8027D321E417D2003C8B10 /* LaunchScreen.m in Sources */,
 				4D0406202383A8CC00F4A422 /* NSDateExtension.swift in Sources */,
+				4D9E27EC243659140043EDF7 /* TPDataLogger.swift in Sources */,
 				4DB275802367E62E00AE891B /* TPNativeHealthBridge.m in Sources */,
 				4D466CB02348FFC30026406B /* main.swift in Sources */,
 				4D08D6872313472A00CBB2F7 /* TPNative.swift in Sources */,

--- a/ios/Tidepool/TPDataLogger.swift
+++ b/ios/Tidepool/TPDataLogger.swift
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2019, Tidepool Project
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the associated License, which is identical to the BSD 2-Clause
+ * License as published by the Open Source Initiative at opensource.org.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the License for more details.
+ *
+ * You should have received a copy of the License along with this program; if
+ * not, you can obtain one from Tidepool Project at tidepool.org.
+ */
+
+import CocoaLumberjack
+import Foundation
+import TPHealthKitUploader
+import HealthKit
+import CSV
+
+class TPDataLogger {
+    static let sharedInstance = TPDataLogger()
+
+    private init() {
+        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+        let cachesDirectory = FileManager.default.urls(for:.cachesDirectory, in: .userDomainMask)[0]
+        
+        loggerInfoMap = [
+            TPUploader.Mode.Current: [
+                HKDataLogPhase.read: [
+                    false: TPDataLoggerInfo(url: cachesDirectory.appendingPathComponent("\(appName)-current-read-samples.csv")),
+                    true: TPDataLoggerInfo(url: cachesDirectory.appendingPathComponent("\(appName)-current-read-deletes.csv")),
+                ],
+                HKDataLogPhase.gather: [
+                    false: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-current-gather-samples.csv")),
+                    true: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-current-gather-deletes.csv")),
+                ],
+                HKDataLogPhase.upload: [
+                    false: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-current-upload-samples.csv")),
+                    true: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-current-upload-deletes.csv")),
+                ]
+            ],
+            TPUploader.Mode.HistoricalAll: [
+                HKDataLogPhase.read: [
+                    false: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-historical-read-samples.csv")),
+                    true: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-historical-read-deletes.csv")),
+                ],
+                HKDataLogPhase.gather: [
+                    false: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-historical-gather-samples.csv")),
+                    true: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-historical-gather-deletes.csv")),
+                ],
+                HKDataLogPhase.upload: [
+                    false: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-historical-upload-samples.csv")),
+                    true: TPDataLoggerInfo(url:cachesDirectory.appendingPathComponent("\(appName)-historical-upload-deletes.csv")),
+                ]
+            ],
+        ]
+    }
+
+    private let dateFormatter = DateFormatter()
+    private let dateFormat = "yyyy-MM-dd HH:mm:ssZ"
+
+    private class TPDataLoggerInfo {
+        init(url: URL) {
+            self.url = url
+        }
+
+        var writer: CSVWriter? = nil
+        var url: URL
+        var needsHeaderRow = false
+    }
+    private var loggerInfoMap: [TPUploader.Mode: [HKDataLogPhase: [Bool: TPDataLoggerInfo]]]
+
+    func dataLogURLs() -> [URL] {
+        var urls = [URL]()
+        for (_, phases) in loggerInfoMap {
+            for (_, isDeletes) in phases {
+                for (_, loggerInfo) in isDeletes {
+                    urls.append(loggerInfo.url)
+                }
+            }
+        }
+        return urls
+    }
+    
+    func openDataLogs(mode: TPUploader.Mode, isFresh: Bool) {
+        let phases = loggerInfoMap[mode]!
+        for (phase, isDeletes) in phases {
+            for (isDelete, _) in isDeletes {
+                openDataLog(mode: mode, phase: phase, isDelete: isDelete, isFresh: isFresh)
+            }
+        }
+    }
+
+    func openDataLog(mode: TPUploader.Mode, phase: HKDataLogPhase, isDelete: Bool, isFresh: Bool) {
+        var writer = loggerInfoMap[mode]?[phase]?[isDelete]?.writer
+        if writer == nil || isFresh {
+            let url = (loggerInfoMap[mode]?[phase]?[isDelete]?.url)!
+            writer = try! CSVWriter(
+                stream: OutputStream(toFileAtPath: url.path, append: !isFresh)!)
+            loggerInfoMap[mode]?[phase]?[isDelete]?.writer = writer
+            var needsHeaderRow = isFresh
+            if !isFresh {
+                if let resources = try? url.resourceValues(forKeys:[.fileSizeKey]),
+                   let fileSize = resources.fileSize,
+                   fileSize > 0 {
+                    needsHeaderRow = false
+                } else {
+                    needsHeaderRow = true
+                }
+            }
+            loggerInfoMap[mode]?[phase]?[isDelete]?.needsHeaderRow = needsHeaderRow
+        }
+    }
+
+    func logData(mode: TPUploader.Mode, phase: HKDataLogPhase, isRetry: Bool, samples: [[String: AnyObject]]?, deletes: [[String: AnyObject]]?) {
+        let logDateString = dateFormatter.isoStringFromDate(Date(), zone: TimeZone.current, dateFormat: dateFormat)
+
+        let iso8601dateZuluDateFormatter = DateFormatter()
+        iso8601dateZuluDateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        iso8601dateZuluDateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        if let samples = samples, samples.count > 0 {
+            let writer = prepareWriter(mode: mode, phase: phase, isDelete: false)
+            for sample in samples {
+                let uuidString = sample["origin"]!["id"] as! String
+                var type = ""
+                var value = 0.0
+                let uploaderSampleType = sample["type"] as! String
+                if uploaderSampleType == "cbg" || type == "smbg" {
+                    type = "BloodGlucose"
+                    value = sample["value"] as! Double
+                } else if uploaderSampleType == "food" {
+                    type = "DietaryCarbohydrates"
+                    value = (sample["nutrition"]!["carbohydrate"] as! [String:Any])["net"] as! Double
+                } else if uploaderSampleType == "basal" {
+                    type = "InsulinDelivery"
+                    value = sample["duration"] as! Double
+                } else if uploaderSampleType == "bolus" {
+                    type = "InsulinDelivery"
+                    value = sample["normal"] as! Double
+                } else if uploaderSampleType == "physicalActivity" {
+                    type = "Workout"
+                    value = sample["duration"] != nil ? sample["duration"]!["value"] as! Double : 0
+                    if value == 0 {
+                        value = sample["distance"] != nil ? sample["distance"]!["value"] as! Double : 0
+                    }
+                    if value == 0 {
+                        value = sample["energy"] != nil ? sample["energy"]!["value"] as! Double : 0
+                    }
+                }
+                
+                let startDate = iso8601dateZuluDateFormatter.date(from: sample["time"] as! String)
+                let startDateString = dateFormatter.isoStringFromDate(startDate!, zone: TimeZone.current, dateFormat: dateFormat)
+                
+                try! writer.write(row: [
+                        logDateString,
+                        uuidString,
+                        type,
+                        startDateString,
+                        value.description,
+                        isRetry.description,
+                    ])
+            }
+        }
+
+        if let deletes = deletes, deletes.count > 0 {
+            let writer = prepareWriter(mode: mode, phase: phase, isDelete: true)
+            for delete in deletes {
+                let uuidString = delete["origin"]!["id"] as! String
+                logData(writer: writer, logDateString: logDateString, uuidString: uuidString, isRetry: isRetry)
+            }
+        }
+    }
+        
+    func logData(mode: TPUploader.Mode, phase: HKDataLogPhase, isRetry: Bool, samples: [HKSample]?, deletes: [HKDeletedObject]?) {
+        let logDateString = dateFormatter.isoStringFromDate(Date(), zone: TimeZone.current, dateFormat: dateFormat)
+
+        if let samples = samples, samples.count > 0 {
+            let writer = prepareWriter(mode: mode, phase: phase, isDelete: false)
+            for sample in samples {
+                logData(writer: writer, logDateString: logDateString, sample: sample, isRetry: isRetry)
+            }
+        }
+
+        if let deletes = deletes, deletes.count > 0 {
+            let writer = prepareWriter(mode: mode, phase: phase, isDelete: true)
+            for delete in deletes {
+                logData(writer: writer, logDateString: logDateString, uuidString: delete.uuid.uuidString, isRetry: isRetry)
+            }
+        }
+    }
+    
+    func logData(writer: CSVWriter, logDateString: String, sample: HKSample, isRetry: Bool) {
+        var value: Double = 0
+        var unitString: String = ""
+        var sampleTypeString = sample.sampleType.identifier
+        if let workout = sample as? HKWorkout {
+            value = workout.duration
+        } else if let quantitySample = sample as? HKQuantitySample {
+            if sampleTypeString == HKQuantityTypeIdentifier.bloodGlucose.rawValue {
+                unitString = "mg/dL"
+                let unit = HKUnit(from: unitString)
+                value = quantitySample.quantity.doubleValue(for: unit)
+            } else if sampleTypeString == HKQuantityTypeIdentifier.dietaryCarbohydrates.rawValue {
+                unitString = "g"
+                let unit = HKUnit(from: unitString)
+                value = quantitySample.quantity.doubleValue(for: unit)
+            } else if sampleTypeString == HKQuantityTypeIdentifier.insulinDelivery.rawValue {
+                let unit = HKUnit.internationalUnit()
+                unitString = unit.unitString
+                value = quantitySample.quantity.doubleValue(for: unit)
+            }
+        }
+
+        // Simplify sampleType before writing
+        sampleTypeString = sampleTypeString.replacingOccurrences(of: "HK", with: "")
+        sampleTypeString = sampleTypeString.replacingOccurrences(of: "Quantity", with: "")
+        sampleTypeString = sampleTypeString.replacingOccurrences(of: "TypeIdentifier", with: "")
+        
+        try! writer.write(row: [
+                logDateString,
+                sample.uuid.uuidString,
+                sampleTypeString,
+                dateFormatter.isoStringFromDate(sample.startDate, zone: TimeZone.current, dateFormat: dateFormat),
+                value.description,
+                isRetry.description,
+            ])
+    }
+
+    func logData(writer: CSVWriter, logDateString: String, uuidString: String, isRetry: Bool) {
+        try! writer.write(row: [
+            logDateString,
+            uuidString,
+            isRetry.description])
+    }
+    
+    func prepareWriter(mode: TPUploader.Mode, phase: HKDataLogPhase, isDelete: Bool) -> CSVWriter {
+        let writer = (loggerInfoMap[mode]?[phase]?[isDelete]?.writer)!
+        let needsHeaderRow = (loggerInfoMap[mode]?[phase]?[isDelete]?.needsHeaderRow)!
+        if needsHeaderRow {
+            if isDelete {
+                try! writer.write(row: [
+                    "logDate",
+                    "uuid",
+                    "retry"
+                ])
+            } else {
+                // newWriter!.
+                try! writer.write(row: [
+                    "logDate",
+                    "uuid",
+                    "type",
+                    "startDate",
+                    "value",
+                    "retry"
+                ])
+            }
+            
+            loggerInfoMap[mode]?[phase]?[isDelete]?.needsHeaderRow = false
+        }
+        
+        return writer
+    }
+}

--- a/ios/Tidepool/TPNativeHealth.swift
+++ b/ios/Tidepool/TPNativeHealth.swift
@@ -100,6 +100,7 @@ class TPNativeHealth: RCTEventEmitter {
             "uploaderSimulate": TPSettings.sharedInstance.uploaderSimulate,
             "includeSensitiveInfo": TPSettings.sharedInstance.includeSensitiveInfo,
             "includeCFNetworkDiagnostics": TPSettings.sharedInstance.includeCFNetworkDiagnostics,
+            "shouldLogHealthData": TPSettings.sharedInstance.shouldLogHealthData,
             "lastCurrentUploadUiDescription": lastCurrentUploadUiDescription()
         ]
     }
@@ -246,6 +247,14 @@ class TPNativeHealth: RCTEventEmitter {
         DDLogInfo("\(#function)")
 
         TPSettings.sharedInstance.setUploaderIncludeCFNetworkDiagnostics(includeCFNetworkDiagnostics)
+        connector.nativeHealthBridge?.onHealthKitInterfaceConfiguration()
+        return true
+    }
+    
+    @objc func setUploaderShouldLogHealthData(_ shouldLogHealthData: Bool) -> NSNumber {
+        DDLogInfo("\(#function)")
+
+        TPSettings.sharedInstance.setUploaderShouldLogHealthData(shouldLogHealthData)
         connector.nativeHealthBridge?.onHealthKitInterfaceConfiguration()
         return true
     }

--- a/ios/Tidepool/TPNativeHealthBridge.m
+++ b/ios/Tidepool/TPNativeHealthBridge.m
@@ -31,6 +31,7 @@ RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(setUploaderSuppressDeletes: (BOOL)suppre
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(setUploaderSimulate: (BOOL)simulate)
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(setUploaderIncludeSensitiveInfo: (BOOL)includeSensitiveInfo)
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(setUploaderIncludeCFNetworkDiagnostics: (BOOL)includeCFNetworkDiagnostics)
+RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(setUploaderShouldLogHealthData: (BOOL)shouldLogHealthData)
 
 RCT_EXTERN_METHOD(startUploadingHistorical)
 RCT_EXTERN_METHOD(stopUploadingHistoricalAndReset)

--- a/ios/Tidepool/TPSettings.swift
+++ b/ios/Tidepool/TPSettings.swift
@@ -29,6 +29,7 @@ let kUserDefaultsUploaderSuppressDeletes = "UploaderSuppressDeletes"
 let kUserDefaultsUploaderSimulate = "UploaderSimulate"
 let kUserDefaultsUploaderIncludeSensitiveInfo = "UploaderIncludeSensitiveInfo"
 let kUserDefaultsUploaderIncludeCFNetworkDiagnostics = "UploaderIncludeCFNetworkDiagnostics"
+let kUserDefaultsUploaderShouldLogHealthData = "kUserDefaultsUploaderShouldLogHealthData"
 
 let kAsyncStorageApiEnvironmentKey = "API_ENVIRONMENT_KEY"
 let kAsyncStorageAuthUserKey = "AUTH_USER_KEY"
@@ -49,6 +50,7 @@ class TPSettings {
     var uploaderSimulate: Bool = false
     var includeSensitiveInfo: Bool = false
     var includeCFNetworkDiagnostics: Bool = false
+    var shouldLogHealthData: Bool = false
 
     var uploaderTimeoutsIndex: Int = 0
     var uploaderTimeouts: [Int] = []
@@ -93,6 +95,7 @@ class TPSettings {
         uploaderSimulate = userDefaults.bool(forKey: kUserDefaultsUploaderSimulate)
         includeSensitiveInfo = userDefaults.bool(forKey: kUserDefaultsUploaderIncludeSensitiveInfo)
         includeCFNetworkDiagnostics = userDefaults.bool(forKey: kUserDefaultsUploaderIncludeCFNetworkDiagnostics)
+        shouldLogHealthData = userDefaults.bool(forKey: kUserDefaultsUploaderShouldLogHealthData)
 
         getValuesForAyncStorageKeys(keys: [kAsyncStorageApiEnvironmentKey, kAsyncStorageAuthUserKey]) { (values: [String?]) in
             // kAsyncStorageApiEnvironmentKey
@@ -158,6 +161,11 @@ class TPSettings {
     func setUploaderIncludeCFNetworkDiagnostics(_ includeCFNetworkDiagnostics: Bool) {
         self.includeCFNetworkDiagnostics = includeCFNetworkDiagnostics
         userDefaults.set(includeCFNetworkDiagnostics, forKey: kUserDefaultsUploaderIncludeCFNetworkDiagnostics)
+    }
+    
+    func setUploaderShouldLogHealthData(_ shouldLogHealthData: Bool) {
+        self.shouldLogHealthData = shouldLogHealthData
+        userDefaults.set(shouldLogHealthData, forKey: kUserDefaultsUploaderShouldLogHealthData)
     }
 
     func getValuesForAyncStorageKeys(keys: [String], values: @escaping ([String?]) -> Void) -> Void {

--- a/ios/Tidepool/TPUploaderAPI.swift
+++ b/ios/Tidepool/TPUploaderAPI.swift
@@ -15,6 +15,7 @@
 
 import CocoaLumberjack
 import Foundation
+import HealthKit
 import TPHealthKitUploader
 
 /// The singleton of this class, accessed and initialized via TPUploaderAPI.connector(), initializes the uploader interface and provides it with the necessary callback functions.
@@ -47,6 +48,7 @@ class TPUploaderAPI: TPUploaderConfigInfo {
 
     private let api: TPApi
     private let dataController: TPDataController
+    private let settings = TPSettings.sharedInstance
 
     //
     // MARK: - TPUploaderConfigInfo protocol
@@ -63,7 +65,7 @@ class TPUploaderAPI: TPUploaderConfigInfo {
 
     func sessionToken() -> String? {
         let result = api.sessionToken
-        let includeSensitiveInfo = TPSettings.sharedInstance.includeSensitiveInfo
+        let includeSensitiveInfo = settings.includeSensitiveInfo
         if includeSensitiveInfo {
             DDLogInfo("\(#function) - TPUploaderConfigInfo protocol, returning: \(result ?? "nil")")
         } else {
@@ -133,27 +135,27 @@ class TPUploaderAPI: TPUploaderConfigInfo {
     }
 
     func samplesUploadLimits() -> [Int] {
-        return TPSettings.sharedInstance.samplesUploadLimits
+        return settings.samplesUploadLimits
     }
     
     func uploaderTimeouts() -> [Int] {
-        return TPSettings.sharedInstance.uploaderTimeouts
+        return settings.uploaderTimeouts
     }
     
     func deletesUploadLimits() -> [Int] {
-        return TPSettings.sharedInstance.deletesUploadLimits
+        return settings.deletesUploadLimits
     }
     
     func supressUploadDeletes() -> Bool {
-        return TPSettings.sharedInstance.uploaderSuppressDeletes
+        return settings.uploaderSuppressDeletes
     }
     
     func simulateUpload() -> Bool {
-        return TPSettings.sharedInstance.uploaderSimulate
+        return settings.uploaderSimulate
     }
     
     func includeSensitiveInfo() -> Bool {
-        return TPSettings.sharedInstance.includeSensitiveInfo
+        return settings.includeSensitiveInfo
     }
 
     let uploadFramework: StaticString = "uploader"
@@ -171,5 +173,21 @@ class TPUploaderAPI: TPUploaderConfigInfo {
 
     func logDebug(_ str: String) {
         DDLogDebug(str, file: uploadFramework, function: uploadFramework)
+    }
+    
+    func openDataLogs(mode: TPUploader.Mode, isFresh: Bool) {
+        TPDataLogger.sharedInstance.openDataLogs(mode: mode, isFresh: isFresh)
+    }
+    
+    func logData(mode: TPUploader.Mode, phase: HKDataLogPhase, isRetry: Bool, samples: [[String: AnyObject]]?, deletes: [[String: AnyObject]]?) {
+        if settings.shouldLogHealthData {
+            TPDataLogger.sharedInstance.logData(mode: mode, phase: phase, isRetry: isRetry, samples: samples, deletes: deletes)
+        }
+    }
+        
+    func logData(mode: TPUploader.Mode, phase: HKDataLogPhase, isRetry: Bool, samples: [HKSample]?, deletes: [HKDeletedObject]?) {
+        if settings.shouldLogHealthData {
+            TPDataLogger.sharedInstance.logData(mode: mode, phase: phase, isRetry: isRetry, samples: samples, deletes: deletes)
+        }
     }
 }

--- a/src/components/DebugSettingsForceCrashListItem.js
+++ b/src/components/DebugSettingsForceCrashListItem.js
@@ -1,4 +1,6 @@
 import React, { PureComponent } from "react";
+import { Alert } from "react-native";
+
 import glamorous, { withTheme } from "glamorous-native";
 
 import { ThemePropType } from "../prop-types/theme";
@@ -10,7 +12,18 @@ class DebugSettingsForceCrashListItem extends PureComponent {
   };
 
   onPress = () => {
-    TPNative.testNativeCrash();
+    Alert.alert("Force Crash?", "", [
+      {
+        text: "Cancel",
+        style: "cancel",
+      },
+      {
+        text: "OK",
+        onPress: () => {
+          TPNative.testNativeCrash();
+        },
+      },
+    ]);
   };
 
   renderButtonText() {

--- a/src/models/TPNativeHealth.js
+++ b/src/models/TPNativeHealth.js
@@ -18,6 +18,7 @@ class TPNativeHealthSingletonClass {
       uploaderSimulate: false,
       includeSensitiveInfo: false,
       includeCFNetworkDiagnostics: false,
+      shouldLogHealthData: false,
     };
 
     this.isUploadingHistorical = false;
@@ -141,6 +142,14 @@ class TPNativeHealthSingletonClass {
       this.nativeModule.setUploaderIncludeCFNetworkDiagnostics(
         includeCFNetworkDiagnostics
       );
+    } catch (error) {
+      // console.log(`error: ${error}`);
+    }
+  }
+
+  setUploaderShouldLogHealthData(shouldLogHealthData) {
+    try {
+      this.nativeModule.setUploaderShouldLogHealthData(shouldLogHealthData);
     } catch (error) {
       // console.log(`error: ${error}`);
     }

--- a/src/screens/DebugHealthScreen.js
+++ b/src/screens/DebugHealthScreen.js
@@ -133,6 +133,29 @@ class DebugHealthScreen extends PureComponent {
     TPNativeHealth.setUploaderIncludeCFNetworkDiagnostics(value);
   };
 
+  onUploaderShouldLogHealthDataValueChange = value => {
+    if (value) {
+      Alert.alert(
+        "Log Health data?",
+        "Enabling this will log Health data for read, gather, and upload phases of the uploader. This is a lot of data. Are you sure?",
+        [
+          {
+            text: "Cancel",
+            style: "cancel",
+          },
+          {
+            text: "OK",
+            onPress: () => {
+              TPNativeHealth.setUploaderShouldLogHealthData(value);
+            },
+          },
+        ]
+      );
+    } else {
+      TPNativeHealth.setUploaderShouldLogHealthData(value);
+    }
+  };
+
   onPressResetButton = () => {
     Alert.alert(
       "Reset Current?",
@@ -407,6 +430,7 @@ class DebugHealthScreen extends PureComponent {
         uploaderSimulate,
         includeSensitiveInfo,
         includeCFNetworkDiagnostics,
+        shouldLogHealthData,
       },
     } = this.props;
 
@@ -488,6 +512,24 @@ class DebugHealthScreen extends PureComponent {
                   this.onUploaderIncludeCFNetworkDiagnosticsValueChange
                 }
                 value={includeCFNetworkDiagnostics}
+              />
+            </Right>
+          </Row>
+        </Grid>
+        <Grid>
+          <Row>
+            <Left styles={styles.left}>
+              <Text>Log Health data</Text>
+            </Left>
+            <Right style={styles.right}>
+              <Switch
+                style={{
+                  transform: [{ scaleX: 0.75 }, { scaleY: 0.75 }],
+                  marginRight: -6,
+                }}
+                trackColor={{ true: Colors.brightBlue, false: null }}
+                onValueChange={this.onUploaderShouldLogHealthDataValueChange}
+                value={shouldLogHealthData}
               />
             </Right>
           </Row>
@@ -669,7 +711,7 @@ class DebugHealthScreen extends PureComponent {
         historicalUploadTotalDays,
         historicalUploadTotalSamples,
         historicalUploadTotalDeletes,
-        historicalUploadEarliestSampleTime, // TODO: my - 0 - use this
+        historicalUploadEarliestSampleTime,
         historicalUploadLatestSampleTime,
       },
     } = this.props;


### PR DESCRIPTION
MOBILE-187: Add data logging support to HK reader/gather/upload and expose via Debug Health

- Add CSV.swift pod for CSV data logging support
- Add new TPDataLogger class for data logging
- Add Debug Health support for enabling data logging
- Add CSV files to the logs that are shared via the share UI

Other
- Add an alert to the Force Crash Debug menu item so user has to confirm before crashing the app
- Fix issue with not showing the alert with spinner for preparing the logs to share

Update to 1.0.7 TPHealthKitUploader to pick up:
- Add data logging support